### PR TITLE
test: improve end-to-end integration assertions

### DIFF
--- a/services/long-term-memory-python/tests/integration/test_end_to_end_flow.py
+++ b/services/long-term-memory-python/tests/integration/test_end_to_end_flow.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import pytest
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 pytestmark = pytest.mark.asyncio
 

--- a/services/long-term-memory-python/tests/integration/test_end_to_end_flow.py
+++ b/services/long-term-memory-python/tests/integration/test_end_to_end_flow.py
@@ -77,10 +77,11 @@ class TestEndToEndFlow:
         
         # 测试消息处理
         result = await message_processor.process_memory_update(memory_update)
-        
-        # 验证处理结果
+
+        # 验证处理结果包含具体字段
         assert result is not None
-        assert "memory_id" in result
+        assert result.get("memory_id") == "mem_001"
+        assert result.get("status") == "success"
         
         # 验证Mem0存储被调用
         mock_mem0_client.add.assert_called_once()
@@ -88,29 +89,29 @@ class TestEndToEndFlow:
         assert call_args["messages"] == memory_update["content"]
         assert call_args["user_id"] == "test_user"
 
-    async def test_memory_updates_subscription_flow(self, message_processor, mock_redis_client):
+    async def test_memory_updates_subscription_flow(self, message_processor, mock_redis_client, mock_mem0_client):
         """测试memory_updates订阅处理流程"""
-        # 模拟订阅消息
         test_message = {
             "user_id": "test_user",
             "content": "用户喜欢编程，特别是Python开发",
             "source": "conversation",
             "timestamp": int(datetime.now().timestamp())
         }
-        
-        # 配置mock返回消息
+
+        # 配置mock的订阅消息生成器
+        async def message_generator():
+            yield {"type": "message", "data": json.dumps(test_message)}
+
         mock_channel = AsyncMock()
-        mock_channel.get_message.side_effect = [
-            {"data": json.dumps(test_message).encode()},
-            None  # 结束循环
-        ]
+        mock_channel.listen = MagicMock(return_value=message_generator())
         mock_redis_client.pubsub.return_value = mock_channel
-        
+
         # 启动订阅处理
         await message_processor.start_memory_updates_subscription()
-        
-        # 验证订阅被创建
-        mock_redis_client.pubsub.assert_called()
+
+        # 验证订阅和消息处理
+        mock_redis_client.pubsub.assert_called_once()
+        assert mock_mem0_client.add.call_count == 1
 
     async def test_cross_service_data_flow(self, memory_service, mock_mem0_client):
         """测试跨服务数据流转"""
@@ -133,10 +134,10 @@ class TestEndToEndFlow:
             query="软件工程师",
             limit=5
         )
-        
-        # 验证搜索结果
+
+        # 验证搜索结果包含预期记忆
         assert len(related_memories) > 0
-        assert "软件工程师" in str(related_memories) or "用户" in str(related_memories)
+        assert related_memories[0]["id"] == "mem_001"
 
     async def test_data_persistence_and_retrieval(self, memory_service, mock_mem0_client):
         """测试数据持久化和检索流程"""
@@ -182,6 +183,7 @@ class TestEndToEndFlow:
         
         # 验证错误处理
         assert result is None or "error" in result
+        mock_mem0_client.add.assert_called_once()
 
     async def test_concurrent_memory_processing(self, memory_service):
         """测试并发记忆处理"""
@@ -216,6 +218,7 @@ class TestEndToEndFlow:
         
         result = await message_processor.process_memory_update(valid_message)
         assert result is not None
+        assert result.get("memory_id") == "mem_001"
         
         # 测试无效消息格式
         invalid_messages = [
@@ -227,30 +230,30 @@ class TestEndToEndFlow:
         for invalid_msg in invalid_messages:
             result = await message_processor.process_memory_update(invalid_msg)
             # 无效消息应该被拒绝或返回错误
-            assert result is None or "error" in result
+            assert result == {"error": "invalid_message_format"}
 
     async def test_system_integration_stability(self, message_processor, memory_service):
         """测试系统集成稳定性"""
-        # 模拟长时间运行的记忆处理
-        test_duration = 0.1  # 秒
+        test_duration = 1.0  # 秒
+        max_messages = 5
         start_time = datetime.now()
-        
+
         processed_count = 0
-        while (datetime.now() - start_time).total_seconds() < test_duration:
+        while processed_count < max_messages and (
+            datetime.now() - start_time
+        ).total_seconds() < test_duration:
             test_message = {
-                "user_id": f"user_{processed_count % 3}",  # 轮换用户
+                "user_id": f"user_{processed_count % 3}",
                 "content": f"稳定性测试消息 {processed_count}",
                 "source": "stability_test",
-                "timestamp": int(datetime.now().timestamp())
+                "timestamp": int(datetime.now().timestamp()),
             }
-            
-            # 处理消息
+
             await message_processor.process_memory_update(test_message)
             processed_count += 1
-            
+
             # 短暂休息避免过载
             await asyncio.sleep(0.01)
-        
-        # 验证处理了足够的消息
-        assert processed_count > 0
-        print(f"稳定性测试：处理了 {processed_count} 条消息")
+
+        # 验证处理的消息数量达到预期
+        assert processed_count == max_messages


### PR DESCRIPTION
## Summary
- add explicit field assertions in end-to-end flow tests
- replace print-based checks with verifiable expectations
- add bounded loop and exit assertion for stability test

## Testing
- `PYTHONPATH=/workspace/Free-Agent-Vtuber/services/long-term-memory-python pytest tests/integration/test_end_to_end_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68c16b2abd488327a05e9ce1b1123091