### PR TITLE
test: add main handlers tests for long-term memory service

### DIFF
--- a/services/long-term-memory-python/tests/conftest.py
+++ b/services/long-term-memory-python/tests/conftest.py
@@ -1,70 +1,64 @@
 """
 测试配置和fixture定义
 """
+
 import asyncio
 import json
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
-from pathlib import Path
 import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 # 添加src目录到Python路径
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.models.memory import MemoryCategory, MemoryMetadata, UserMemory, UserProfile
-from src.models.messages import MemoryUpdateMessage, LTMRequest, LTMResponse
+from src.models.messages import LTMRequest, LTMResponse, MemoryUpdateMessage
 
 
 @pytest.fixture
 def test_config():
     """测试配置"""
     return {
-        "redis": {
-            "host": "localhost",
-            "port": 6379,
-            "db": 1  # 使用测试数据库
-        },
+        "redis": {"host": "localhost", "port": 6379, "db": 1},  # 使用测试数据库
         "qdrant": {
             "host": "localhost",
             "port": 6333,
-            "collection_name": "test_mem0_collection"
+            "collection_name": "test_mem0_collection",
         },
-        "mem0": {
-            "config_path": "config/mem0_config.yaml"
-        },
+        "mem0": {"config_path": "config/mem0_config.yaml"},
         "channels": {
             "memory_updates": "memory_updates",
-            "ltm_responses": "ltm_responses"
+            "ltm_responses": "ltm_responses",
         },
-        "queues": {
-            "ltm_requests": "ltm_requests"
-        }
+        "queues": {"ltm_requests": "ltm_requests"},
     }
 
 
 @pytest.fixture
 def mock_redis():
     """Mock Redis客户端"""
-    from unittest.mock import Mock, AsyncMock
-    
+    from unittest.mock import AsyncMock, Mock
+
     mock = AsyncMock()
     mock.get.return_value = None
     mock.setex.return_value = True
     mock.publish.return_value = 1
     mock.lpush.return_value = 1
     mock.brpop.return_value = None
-    
+
     # Mock pubsub behavior
     from unittest.mock import Mock
+
     mock_pubsub_instance = Mock()
     mock_pubsub_instance.subscribe = AsyncMock()
     mock_pubsub_instance.unsubscribe = AsyncMock()
     mock_pubsub_instance.close = AsyncMock()
     # listen()应该返回一个可以被async for迭代的对象
     mock_pubsub_instance.listen = Mock()
-    
+
     # pubsub()是同步方法，使用Mock而不是AsyncMock
     mock.pubsub = Mock(return_value=mock_pubsub_instance)
     return mock
@@ -99,7 +93,7 @@ def sample_memory_metadata():
         confidence=0.8,
         source="conversation",
         tags=["动漫", "娱乐"],
-        created_at=datetime.now()
+        created_at=datetime.now(),
     )
 
 
@@ -109,7 +103,7 @@ def sample_user_memory(sample_memory_metadata):
     return UserMemory(
         user_id="test_user_001",
         content="用户喜欢看动漫，特别是《进击的巨人》",
-        metadata=sample_memory_metadata
+        metadata=sample_memory_metadata,
     )
 
 
@@ -123,7 +117,7 @@ def sample_user_profile():
         habits=["晚上聊天", "喜欢分享"],
         important_events=["2024年生日"],
         memory_count=5,
-        last_updated=datetime.now()
+        last_updated=datetime.now(),
     )
 
 
@@ -135,7 +129,7 @@ def sample_memory_update_message():
         content="我最喜欢的动漫是《进击的巨人》",
         source="conversation",
         timestamp=1234567890,
-        meta={"session_id": "session_001"}
+        meta={"session_id": "session_001"},
     )
 
 
@@ -146,9 +140,5 @@ def sample_ltm_request():
         request_id="req_1234567890",
         type="search",
         user_id="test_user_001",
-        data={
-            "query": "用户喜欢什么动漫",
-            "limit": 5
-        }
+        data={"query": "用户喜欢什么动漫", "limit": 5},
     )
-

--- a/services/long-term-memory-python/tests/unit/test_main_handlers.py
+++ b/services/long-term-memory-python/tests/unit/test_main_handlers.py
@@ -1,0 +1,124 @@
+import asyncio
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from main import _handle_ltm_requests, _handle_memory_updates
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_updates_processes_and_cleans():
+    redis_client = AsyncMock()
+    pubsub = AsyncMock()
+    redis_client.pubsub = MagicMock(return_value=pubsub)
+
+    message = {
+        "type": "message",
+        "data": json.dumps(
+            {
+                "user_id": "user1",
+                "content": "hello",
+                "source": "conversation",
+                "timestamp": 123,
+                "meta": {"session_id": "sess1"},
+            }
+        ),
+    }
+
+    async def listen():
+        yield message
+        await asyncio.sleep(1)
+
+    pubsub.listen = MagicMock(return_value=listen())
+
+    mem0 = AsyncMock()
+
+    task = asyncio.create_task(
+        _handle_memory_updates(redis_client, mem0, "memory_updates")
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    mem0.add_memory.assert_called_once_with(
+        {
+            "user_id": "user1",
+            "content": "hello",
+            "metadata": {
+                "source": "conversation",
+                "timestamp": 123,
+                "session_id": "sess1",
+            },
+        }
+    )
+    pubsub.unsubscribe.assert_called_once_with("memory_updates")
+    pubsub.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_ltm_requests_search_publishes_response():
+    redis_client = AsyncMock()
+    mem0 = AsyncMock()
+    mem0.search.return_value = [{"id": "m1", "memory": "hi"}]
+
+    request = {
+        "request_id": "r1",
+        "user_id": "u1",
+        "type": "search",
+        "data": {"query": "hi", "limit": 2},
+    }
+
+    redis_client.brpop = AsyncMock(
+        side_effect=[("ltm_requests", json.dumps(request)), None]
+    )
+    redis_client.publish = AsyncMock()
+
+    task = asyncio.create_task(
+        _handle_ltm_requests(redis_client, mem0, "ltm_requests", "ltm_responses")
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    mem0.search.assert_called_once_with(query="hi", user_id="u1", limit=2)
+    redis_client.publish.assert_called()
+    published = json.loads(redis_client.publish.call_args[0][1])
+    assert published["request_id"] == "r1"
+    assert published["user_id"] == "u1"
+    assert published["memories"] == [{"id": "m1", "memory": "hi"}]
+    assert published["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_ltm_requests_unknown_type_error():
+    redis_client = AsyncMock()
+    mem0 = AsyncMock()
+
+    request = {
+        "request_id": "r2",
+        "user_id": "u2",
+        "type": "unknown",
+    }
+
+    redis_client.brpop = AsyncMock(
+        side_effect=[("ltm_requests", json.dumps(request)), None]
+    )
+    redis_client.publish = AsyncMock()
+
+    task = asyncio.create_task(
+        _handle_ltm_requests(redis_client, mem0, "ltm_requests", "ltm_responses")
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    mem0.search.assert_not_called()
+    mem0.add_memory.assert_not_called()
+    published = json.loads(redis_client.publish.call_args[0][1])
+    assert published["success"] is False
+    assert published["error"] == "unknown_request_type:unknown"


### PR DESCRIPTION
## Summary
- add unit tests for memory update and request handlers
- fix test path resolution for long-term-memory service
- align integration test invalid message coverage with message processor

## Testing
- `flake8 .` *(fails: command not found)*
- `mypy --explicit-package-bases .` *(fails: missing stubs and type errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2ace4e918832788dcb4239f23c2f5