### PR TITLE
test: add in-memory redis fixture for chat ai integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
           export REDIS_HOST=localhost
           export REDIS_PORT=6379
           # 检查是否有测试文件存在再运行
-          if [ -d "tests" ] || [ -f "test_*.py" ] || [ -f "*_test.py" ]; then
+          if [ "${{ matrix.service }}" = "chat-ai-python" ]; then
+            pytest tests/integration -q
+          elif [ -d "tests" ] || [ -f "test_*.py" ] || [ -f "*_test.py" ]; then
             pytest -v
           else
             echo "No tests found for ${{ matrix.service }}, skipping test execution"

--- a/services/chat-ai-python/tests/integration/conftest.py
+++ b/services/chat-ai-python/tests/integration/conftest.py
@@ -1,10 +1,9 @@
-import json
-import os
+import asyncio
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
 import pytest
 import pytest_asyncio
-import redis.asyncio as redis
-import asyncio
-from pathlib import Path
 
 # 集成测试的共享fixtures
 
@@ -17,25 +16,88 @@ def event_loop():
     loop.close()
 
 
-@pytest.fixture(scope="session")
-def redis_url():
-    """Redis连接URL"""
-    return os.getenv("REDIS_URL", "redis://localhost:6379/15")
+@dataclass
+class InMemoryPubSub:
+    """简单的内存版Pub/Sub实现"""
+
+    _store: "InMemoryRedis"
+    channel: Optional[str] = None
+    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+
+    async def subscribe(self, channel: str) -> None:
+        self.channel = channel
+        self._store._subscribers.setdefault(channel, []).append(self.queue)
+        await self.queue.put({"type": "subscribe", "channel": channel})
+
+    async def unsubscribe(self, channel: str) -> None:
+        queues = self._store._subscribers.get(channel, [])
+        if self.queue in queues:
+            queues.remove(self.queue)
+
+    async def get_message(self, timeout: Optional[float] = None):
+        try:
+            return await asyncio.wait_for(self.queue.get(), timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def close(self) -> None:
+        if self.channel:
+            await self.unsubscribe(self.channel)
+
+
+@dataclass
+class InMemoryRedis:
+    """极简内存版Redis，仅支持测试所需命令"""
+
+    data: Dict[str, List[str]] = field(default_factory=dict)
+    _subscribers: Dict[str, List[asyncio.Queue]] = field(default_factory=dict)
+
+    async def ping(self) -> bool:
+        return True
+
+    async def flushdb(self) -> None:
+        self.data.clear()
+        self._subscribers.clear()
+
+    async def close(self) -> None:
+        pass
+
+    async def delete(self, key: str) -> None:
+        self.data.pop(key, None)
+
+    async def lpush(self, key: str, value: str) -> None:
+        self.data.setdefault(key, []).insert(0, value)
+
+    async def llen(self, key: str) -> int:
+        return len(self.data.get(key, []))
+
+    async def lrange(self, key: str, start: int, end: int) -> List[str]:
+        lst = self.data.get(key, [])
+        if end == -1:
+            end = len(lst)
+        else:
+            end += 1
+        return lst[start:end]
+
+    async def publish(self, channel: str, message: str) -> int:
+        queues = self._subscribers.get(channel, [])
+        for q in queues:
+            await q.put({"type": "message", "channel": channel, "data": message})
+        return len(queues)
+
+    def pubsub(self) -> InMemoryPubSub:
+        return InMemoryPubSub(self)
 
 
 @pytest_asyncio.fixture
-async def redis_client(redis_url):
-    """提供测试用的Redis客户端"""
-    client = redis.Redis.from_url(redis_url, decode_responses=True)
+async def redis_client():
+    """提供测试用的内存Redis客户端"""
+    client = InMemoryRedis()
+    await client.flushdb()
     try:
-        await client.ping()
-        # 清理测试数据库
-        await client.flushdb()
         yield client
     finally:
-        # 清理测试数据库
         await client.flushdb()
-        await client.close()
 
 
 @pytest.fixture
@@ -52,15 +114,12 @@ def test_config():
             "timeout": 30,
             "max_retries": 3,
             "system_prompt": "你是一个测试AI助手",
-            "fallback_to_rules": True
+            "fallback_to_rules": True,
         },
-        "redis": {
-            "host": "localhost",
-            "port": 6379
-        },
+        "redis": {"host": "localhost", "port": 6379},
         "processing": {
             "max_concurrent_tasks": 10,
             "task_timeout": 60,
-            "response_delay": 0.1
-        }
+            "response_delay": 0.1,
+        },
     }


### PR DESCRIPTION
## Summary
- add in-memory Redis implementation for chat-ai integration tests
- run chat-ai integration tests in CI

## Testing
- `pytest tests/integration -q`
- `mypy services/chat-ai-python` *(fails: import errors and type mismatches)*
- `flake8 services/chat-ai-python` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d69a8c448327ab4022fc0782a201