### PR TITLE
test: add in-memory redis fixture for chat ai integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           export REDIS_PORT=6379
           # 检查是否有测试文件存在再运行
           if [ "${{ matrix.service }}" = "chat-ai-python" ]; then
+            pytest tests/unit -v
             pytest tests/integration -q
           elif [ -d "tests" ] || [ -f "test_*.py" ] || [ -f "*_test.py" ]; then
             pytest -v


### PR DESCRIPTION
## Summary
- add in-memory Redis implementation for chat-ai integration tests
- run chat-ai unit and integration tests in CI

## Testing
- `pytest tests/unit -q`
- `pytest tests/integration -q`
- `flake8 .` *(fails: flake8 not installed; installation blocked)*
- `mypy .` *(fails: missing stubs and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2db8452908327ae49725773ddeaab