### PR TITLE
test: reset backend services after gateway integration tests

### DIFF
--- a/services/gateway-python/tests/integration/conftest.py
+++ b/services/gateway-python/tests/integration/conftest.py
@@ -70,6 +70,7 @@ def gateway_server():
     """启动网关服务"""
     os.environ["INPUT_HANDLER_URL"] = "ws://127.0.0.1:8001"
     os.environ["OUTPUT_HANDLER_URL"] = "ws://127.0.0.1:8001"
+    original_services = main.BACKEND_SERVICES.copy()
     main.BACKEND_SERVICES["input"] = os.environ["INPUT_HANDLER_URL"]
     main.BACKEND_SERVICES["output"] = os.environ["OUTPUT_HANDLER_URL"]
 
@@ -93,3 +94,5 @@ def gateway_server():
         del os.environ["INPUT_HANDLER_URL"]
     if "OUTPUT_HANDLER_URL" in os.environ:
         del os.environ["OUTPUT_HANDLER_URL"]
+    main.BACKEND_SERVICES.clear()
+    main.BACKEND_SERVICES.update(original_services)


### PR DESCRIPTION
## Summary
- save and restore BACKEND_SERVICES in gateway integration tests to avoid cross-test contamination

## Testing
- `isort tests/integration/conftest.py`
- `black tests/integration/conftest.py`
- `flake8 .` *(command not found: flake8)*
- `mypy tests/integration/conftest.py`
- `pytest tests/integration/test_websocket_proxy_integration.py -q`
- `pytest -q` *(hung after completion; manual interrupt showed 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2def4c72c83279d0e1a035a2adc48