### PR TITLE
test: stabilize gateway tests

### DIFF
--- a/services/gateway-python/tests/integration/test_websocket_proxy_integration.py
+++ b/services/gateway-python/tests/integration/test_websocket_proxy_integration.py
@@ -1,15 +1,18 @@
-import pytest
 import asyncio
-import websockets
 import json
+from typing import Any, cast
 from unittest.mock import patch
+
+import pytest
+import websockets
 
 # 检查是否可以导入所需模块
 try:
-    import httpx
+    import httpx  # type: ignore
+
     HAS_HTTPX = True
 except ImportError:
-    httpx = None
+    httpx = cast(Any, None)
     HAS_HTTPX = False
 
 
@@ -18,12 +21,12 @@ async def test_websocket_input_proxy_integration(gateway_server, mock_backend_se
     """测试输入WebSocket代理的集成"""
     # 连接到网关
     gateway_uri = f"{gateway_server}/ws/input"
-    
+
     async with websockets.connect(gateway_uri) as gateway_ws:
         # 发送消息
         test_message = "Hello, Gateway!"
         await gateway_ws.send(test_message)
-        
+
         # 接收回显消息
         response = await gateway_ws.recv()
         assert response == f"Echo: {test_message}"
@@ -35,12 +38,12 @@ async def test_websocket_output_proxy_integration(gateway_server, mock_backend_s
     # 连接到网关的输出端点
     task_id = "test_task_123"
     gateway_uri = f"{gateway_server}/ws/output/{task_id}"
-    
+
     async with websockets.connect(gateway_uri) as gateway_ws:
         # 发送消息
         test_message = "Hello, Output!"
         await gateway_ws.send(test_message)
-        
+
         # 接收回显消息
         response = await gateway_ws.recv()
         assert response == f"Output: {test_message}"
@@ -51,24 +54,24 @@ async def test_multiple_concurrent_connections(gateway_server, mock_backend_serv
     """测试多个并发连接"""
     connections = []
     messages = []
-    
+
     try:
         # 创建多个并发连接
         for i in range(3):
             uri = f"{gateway_server}/ws/input"
             ws = await websockets.connect(uri)
             connections.append(ws)
-            
+
             # 发送唯一消息
             message = f"Message {i}"
             await ws.send(message)
             messages.append(message)
-        
+
         # 接收所有响应
         for i, ws in enumerate(connections):
             response = await ws.recv()
             assert response == f"Echo: {messages[i]}"
-            
+
     finally:
         # 关闭所有连接
         for ws in connections:
@@ -79,52 +82,56 @@ async def test_multiple_concurrent_connections(gateway_server, mock_backend_serv
 async def test_connection_cleanup_on_disconnect(gateway_server, mock_backend_server):
     """测试连接断开时的清理"""
     from main import active_connections
-    
+
     # 确保初始状态干净
     active_connections.clear()
-    
+
     # 连接然后断开
     gateway_uri = f"{gateway_server}/ws/input"
     ws = await websockets.connect(gateway_uri)
-    
+
     # 发送一条消息
     await ws.send("Test message")
     response = await ws.recv()
     assert response == "Echo: Test message"
-    
+
     # 记录连接数
     initial_count = len(active_connections)
-    
+
     # 关闭连接
     await ws.close()
-    
+
     # 等待一段时间让清理完成
     await asyncio.sleep(0.1)
-    
+
     # 验证连接已被清理
     # 注意：由于是异步操作，清理可能不会立即完成
 
 
 @pytest.mark.asyncio
-async def test_health_check_during_active_connections(gateway_server, mock_backend_server):
+async def test_health_check_during_active_connections(
+    gateway_server, mock_backend_server
+):
     """测试有活跃连接时的健康检查"""
     import httpx
-    
+
     # 先建立一个WebSocket连接
     gateway_uri = f"{gateway_server}/ws/input"
     ws = await websockets.connect(gateway_uri)
-    
+
     # 发送一条消息
     await ws.send("Test message")
     response = await ws.recv()
     assert response == "Echo: Test message"
-    
+
     # 检查健康状态
     http_client = httpx.AsyncClient()
     try:
-        response = await http_client.get(f"{gateway_server.replace('ws', 'http')}/health")
+        response = await http_client.get(
+            f"{gateway_server.replace('ws', 'http')}/health"
+        )
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["status"] == "ok"
         # 注意：由于连接管理的异步特性，活跃连接数可能不会立即更新

--- a/services/gateway-python/tests/unit/test_health_check.py
+++ b/services/gateway-python/tests/unit/test_health_check.py
@@ -1,100 +1,80 @@
 import pytest
-import json
+from fastapi.testclient import TestClient
 
-# 检查是否可以导入TestClient
-try:
-    from fastapi.testclient import TestClient
-    # 导入要测试的模块
-    from main import app, active_connections
-    
-    # 创建测试客户端
-    client = TestClient(app)
-    HAS_TEST_CLIENT = True
-except ImportError:
-    HAS_TEST_CLIENT = False
-    app = None
-    active_connections = {}
-    TestClient = None
+from main import active_connections, app
 
 
-def test_health_check_endpoint():
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def test_health_check_endpoint(client):
     """测试健康检查端点的详细内容"""
     response = client.get("/health")
     assert response.status_code == 200
-    
+
     data = response.json()
     assert data["status"] == "ok"
     assert data["gateway"] == "running"
     assert isinstance(data["active_connections"], int)
     assert "backend_services" in data
-    
-    # 验证后端服务配置格式
+
     backend_services = data["backend_services"]
     assert "input" in backend_services
     assert "output" in backend_services
 
 
-def test_health_check_response_headers():
+def test_health_check_response_headers(client):
     """测试健康检查端点的响应头部"""
     response = client.get("/health")
     assert response.status_code == 200
-    
-    # 检查Content-Type头部
     assert response.headers["content-type"] == "application/json"
 
 
-def test_health_check_with_active_connections():
+def test_health_check_with_active_connections(client):
     """测试有活跃连接时的健康检查"""
-    # 添加一些模拟连接
     active_connections["input_1"] = "mock_websocket_1"
     active_connections["output_1"] = "mock_websocket_2"
-    
+
     response = client.get("/health")
     assert response.status_code == 200
-    
     data = response.json()
     assert data["active_connections"] == 2
-    
-    # 清理模拟连接
+
     active_connections.clear()
 
 
-def test_connections_endpoint_structure():
+def test_connections_endpoint_structure(client):
     """测试连接端点返回的数据结构"""
-    # 添加一些模拟连接
     active_connections["input_1"] = "mock_websocket_1"
     active_connections["output_2"] = "mock_websocket_2"
-    
+
     response = client.get("/connections")
     assert response.status_code == 200
-    
+
     data = response.json()
     assert "total_connections" in data
     assert "connections" in data
     assert isinstance(data["total_connections"], int)
     assert isinstance(data["connections"], list)
-    
-    # 验证连接数量
     assert data["total_connections"] == 2
     assert len(data["connections"]) == 2
-    
-    # 验证连接ID格式
     for conn_id in data["connections"]:
         assert isinstance(conn_id, str)
-        assert "_" in conn_id  # 应该包含类型和ID，如 "input_1"
-    
-    # 清理模拟连接
+        assert "_" in conn_id
+
     active_connections.clear()
 
 
-def test_empty_connections():
+def test_empty_connections(client):
     """测试没有连接时的连接端点"""
-    # 确保没有活跃连接
     active_connections.clear()
-    
+
     response = client.get("/connections")
     assert response.status_code == 200
-    
+
     data = response.json()
     assert data["total_connections"] == 0
     assert data["connections"] == []

--- a/services/gateway-python/tests/unit/test_routes.py
+++ b/services/gateway-python/tests/unit/test_routes.py
@@ -8,7 +8,8 @@ from main import active_connections, app
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    with TestClient(app) as c:
+        yield c
 
 
 def test_root_endpoint(client):

--- a/services/gateway-python/tests/unit/test_websocket_proxy.py
+++ b/services/gateway-python/tests/unit/test_websocket_proxy.py
@@ -1,6 +1,7 @@
-import pytest
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 import websockets
 from websockets.exceptions import ConnectionClosed
 
@@ -20,16 +21,16 @@ async def test_websocket_proxy_initialization():
 async def test_proxy_websocket_success(mock_websocket, mock_websocket_connection):
     """测试成功的WebSocket代理连接"""
     proxy = WebSocketProxy()
-    
+
     # 模拟websockets.connect
-    with patch('websockets.connect', return_value=mock_websocket_connection):
+    with patch("websockets.connect", return_value=mock_websocket_connection):
         # 模拟_forward_messages方法
-        with patch.object(proxy, '_forward_messages', new_callable=AsyncMock):
+        with patch.object(proxy, "_forward_messages", new_callable=AsyncMock):
             await proxy.proxy_websocket(mock_websocket, "ws://localhost:8001", "input")
-            
+
             # 验证WebSocket连接被接受
             mock_websocket.accept.assert_called_once()
-            
+
             # 验证连接被添加到活跃连接中
             # 注意：由于是异步测试，实际的连接管理可能在_mock_forward_messages中被处理
 
@@ -38,36 +39,38 @@ async def test_proxy_websocket_success(mock_websocket, mock_websocket_connection
 async def test_proxy_websocket_connection_error(mock_websocket):
     """测试WebSocket代理连接错误"""
     proxy = WebSocketProxy()
-    
+
     # 模拟websockets.connect抛出异常
-    with patch('websockets.connect', side_effect=Exception("连接失败")):
+    with patch("websockets.connect", side_effect=Exception("连接失败")):
         await proxy.proxy_websocket(mock_websocket, "ws://localhost:8001", "input")
-        
+
         # 验证WebSocket连接被关闭
-        mock_websocket.close.assert_called_once_with(code=1011, reason="Proxy error: 连接失败")
+        mock_websocket.close.assert_called_once_with(
+            code=1011, reason="Proxy error: 连接失败"
+        )
 
 
 @pytest.mark.asyncio
 async def test_forward_messages_fastapi_websocket(mock_websocket):
     """测试_forward_messages方法处理FastAPI WebSocket"""
     proxy = WebSocketProxy()
-    
+
     # 创建一个模拟的目标WebSocket
     mock_destination = AsyncMock()
-    
+
     # 模拟消息流
     messages = [
         {"type": "websocket.receive", "text": "Hello"},
         {"type": "websocket.receive", "bytes": b"binary data"},
-        {"type": "websocket.disconnect"}
+        {"type": "websocket.disconnect"},
     ]
-    
+
     # 设置消息迭代
     mock_websocket.receive.side_effect = messages
-    
+
     # 调用转发方法
     await proxy._forward_messages(mock_websocket, mock_destination, "test_direction")
-    
+
     # 验证消息被正确转发
     mock_destination.send.assert_any_call("Hello")
     mock_destination.send.assert_any_call(b"binary data")
@@ -77,19 +80,26 @@ async def test_forward_messages_fastapi_websocket(mock_websocket):
 async def test_forward_messages_websockets_library():
     """测试_forward_messages方法处理websockets库WebSocket"""
     proxy = WebSocketProxy()
-    
-    # 创建模拟的源和目标WebSocket
-    mock_source = AsyncMock()
-    mock_destination = AsyncMock()
-    
-    # 模拟消息流
+
+    class MockWebSocket:
+        def __init__(self, msgs):
+            self._iter = iter(msgs)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
     messages = ["Hello", b"binary data"]
-    mock_source.__aiter__.return_value = iter(messages)
-    
-    # 调用转发方法
+    mock_source = MockWebSocket(messages)
+    mock_destination = AsyncMock()
+
     await proxy._forward_messages(mock_source, mock_destination, "test_direction")
-    
-    # 验证消息被正确转发
+
     mock_destination.send_text.assert_called_once_with("Hello")
     mock_destination.send_bytes.assert_called_once_with(b"binary data")
 
@@ -98,14 +108,16 @@ async def test_forward_messages_websockets_library():
 async def test_forward_messages_websocket_disconnect():
     """测试_forward_messages方法处理WebSocket断开连接"""
     proxy = WebSocketProxy()
-    
+
     # 创建模拟的源和目标WebSocket
     mock_source = AsyncMock()
     mock_destination = AsyncMock()
-    
+
     # 模拟WebSocket断开连接异常
-    mock_source.receive.side_effect = websockets.exceptions.ConnectionClosed(1000, "Normal closure")
-    
+    mock_source.receive.side_effect = websockets.exceptions.ConnectionClosed(
+        1000, "Normal closure"
+    )
+
     # 调用转发方法，应该不会抛出异常
     await proxy._forward_messages(mock_source, mock_destination, "test_direction")
 
@@ -114,14 +126,14 @@ async def test_forward_messages_websocket_disconnect():
 async def test_forward_messages_general_exception():
     """测试_forward_messages方法处理一般异常"""
     proxy = WebSocketProxy()
-    
+
     # 创建模拟的源和目标WebSocket
     mock_source = AsyncMock()
     mock_destination = AsyncMock()
-    
+
     # 模拟一般异常
     mock_source.receive.side_effect = Exception("General error")
-    
+
     # 调用转发方法，应该抛出异常
     with pytest.raises(Exception, match="General error"):
         await proxy._forward_messages(mock_source, mock_destination, "test_direction")


### PR DESCRIPTION
## Summary
- ensure FastAPI TestClient instances are closed during gateway tests
- avoid infinite loop in WebSocket proxy test by using custom async iterator
- annotate optional httpx import to satisfy mypy

## Testing
- `pytest -q`
- `cd services/asr-python && pytest -q`
- `cd services/chat-ai-python && pytest -q`
- `cd services/input-handler-python && pytest -q`
- `cd services/memory-python && pytest -q`
- `cd services/tts-python && pytest -q`
- `cd services/output-handler-python && pytest -q`
- `cd services/long-term-memory-python && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e1fb4dc88327a65c419652cc084f