### PR TITLE
feat: enable long-term memory integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ PGVECTOR_PASSWORD=ltm_password
 
 # 长期记忆服务配置
 MEM0_CONFIG_PATH=config/mem0_config.yaml
+ENABLE_LTM=true
+LTM_REQUESTS_QUEUE=ltm_requests
+LTM_RESPONSES_CHANNEL=ltm_responses
 
 # 网络配置
 INPUT_HANDLER_URL=ws://input-handler:8001

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ cd Free-Agent-Vtuber
 cp .env.example .env
 ```
 
+`.env` 默认开启 `ENABLE_LTM=true`，如需禁用长期记忆可将其设为 `false`。
+
 ### Docker 一键启动
 
 ```bash
@@ -141,7 +143,7 @@ pytest -q
 
 #### 未来展望
 
-* [ ] **长期记忆模块**：集成数据库，让 Agent 拥有记忆
+* [x] **长期记忆模块**：集成数据库，让 Agent 拥有记忆
 * [ ] **情感感知模块**：通过文本分析赋予 Agent 情感表达能力
 * [ ] **视觉感知模块**：让 Agent 能够 "看到" 屏幕或摄像头
 * [ ] **工具使用模块**：允许 Agent 调用外部 API（天气、搜索等）

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -143,9 +143,9 @@ services:
       - REDIS_PORT=6379
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - PYTHONPATH=/app
-      - ENABLE_LTM=true
-      - LTM_REQUESTS_QUEUE=ltm_requests
-      - LTM_RESPONSES_CHANNEL=ltm_responses
+      - ENABLE_LTM=${ENABLE_LTM:-true}
+      - LTM_REQUESTS_QUEUE=${LTM_REQUESTS_QUEUE:-ltm_requests}
+      - LTM_RESPONSES_CHANNEL=${LTM_RESPONSES_CHANNEL:-ltm_responses}
     volumes:
       - ./services/chat-ai-python:/app
       - ./utils:/app/shared_utils
@@ -153,7 +153,6 @@ services:
     restart: "no"
     depends_on:
       - redis
-      - long-term-memory
 
   # 输出处理服务
   output-handler:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -143,6 +143,9 @@ services:
       - REDIS_PORT=6379
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - PYTHONPATH=/app
+      - ENABLE_LTM=true
+      - LTM_REQUESTS_QUEUE=ltm_requests
+      - LTM_RESPONSES_CHANNEL=ltm_responses
     volumes:
       - ./services/chat-ai-python:/app
       - ./utils:/app/shared_utils
@@ -150,6 +153,7 @@ services:
     restart: "no"
     depends_on:
       - redis
+      - long-term-memory
 
   # 输出处理服务
   output-handler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,15 @@ services:
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ENABLE_LTM=${ENABLE_LTM:-true}
+      - LTM_REQUESTS_QUEUE=${LTM_REQUESTS_QUEUE:-ltm_requests}
+      - LTM_RESPONSES_CHANNEL=${LTM_RESPONSES_CHANNEL:-ltm_responses}
     restart: unless-stopped
     depends_on:
       redis:
         condition: service_healthy
+      long-term-memory:
+        condition: service_started
 
   # 网关服务
   gateway:


### PR DESCRIPTION
## Summary
- enable long-term memory lookups in chat-ai by default
- expose long-term memory env vars in compose and `.env.example`
- document long-term memory feature in README

## Testing
- `cd services/long-term-memory-python && pytest -q`
- `cd services/chat-ai-python && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c580fd94648327996ceee1531b1680