### PR TITLE
feat: make mem0 provider selection pluggable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ PGVECTOR_PASSWORD=ltm_password
 
 # 长期记忆服务配置
 MEM0_CONFIG_PATH=config/mem0_config.yaml
+# MEM0_LLM_PROVIDER=openai
+# MEM0_LLM_CONFIG_JSON={"model": "gpt-4o-mini", "temperature": 0.1}
+# MEM0_EMBEDDER_PROVIDER=openai
+# MEM0_EMBEDDER_CONFIG_JSON={"model": "text-embedding-3-small"}
 ENABLE_LTM=true
 LTM_REQUESTS_QUEUE=ltm_requests
 LTM_RESPONSES_CHANNEL=ltm_responses

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -161,6 +161,11 @@ services:
       - PGVECTOR_USER=${POSTGRES_USER:-ltm_user}
       - PGVECTOR_PASSWORD=${POSTGRES_PASSWORD:-ltm_password}
       - MEM0_CONFIG_PATH=config/mem0_config.yaml
+      - MEM0_LLM_PROVIDER=${MEM0_LLM_PROVIDER:-}
+      - MEM0_LLM_CONFIG_JSON=${MEM0_LLM_CONFIG_JSON:-}
+      - MEM0_EMBEDDER_PROVIDER=${MEM0_EMBEDDER_PROVIDER:-}
+      - MEM0_EMBEDDER_CONFIG_JSON=${MEM0_EMBEDDER_CONFIG_JSON:-}
+      - MEM0_API_KEY=${MEM0_API_KEY:-}
       - PYTHONPATH=/app
     volumes:
       - ./services/long-term-memory-python:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,11 @@ services:
       - PGVECTOR_USER=${POSTGRES_USER:-ltm_user}
       - PGVECTOR_PASSWORD=${POSTGRES_PASSWORD:-ltm_password}
       - MEM0_CONFIG_PATH=config/mem0_config.yaml
+      - MEM0_LLM_PROVIDER=${MEM0_LLM_PROVIDER:-}
+      - MEM0_LLM_CONFIG_JSON=${MEM0_LLM_CONFIG_JSON:-}
+      - MEM0_EMBEDDER_PROVIDER=${MEM0_EMBEDDER_PROVIDER:-}
+      - MEM0_EMBEDDER_CONFIG_JSON=${MEM0_EMBEDDER_CONFIG_JSON:-}
+      - MEM0_API_KEY=${MEM0_API_KEY:-}
     volumes:
       - ltm_data:/app/data
       - ltm_logs:/app/logs

--- a/docs/env-mem0-providers.md
+++ b/docs/env-mem0-providers.md
@@ -17,9 +17,40 @@ overrides instead of editing tracked files.
 | Mem0 API key (Cloud)   | `MEM0_API_KEY`               | Required for Mem0 Cloud users. Not needed for self-hosted Mem0. |
 | Base config path       | `MEM0_CONFIG_PATH`           | Defaults to `config/mem0_config.yaml`. Set when mounting a custom config. |
 | LLM provider override  | `MEM0_LLM_PROVIDER`          | Will be consumed once Phase 2 introduces runtime overrides. |
-| LLM config JSON        | `MEM0_LLM_CONFIG_JSON`       | JSON string with provider-specific options (Phase 2). |
+| LLM config JSON        | `MEM0_LLM_CONFIG_JSON`       | JSON string with provider-specific options (Phase 2+). |
 | Embedder provider      | `MEM0_EMBEDDER_PROVIDER`     | Used together with `MEM0_LLM_PROVIDER`. |
-| Embedder config JSON   | `MEM0_EMBEDDER_CONFIG_JSON`  | JSON string with embedder options (Phase 2). |
+| Embedder config JSON   | `MEM0_EMBEDDER_CONFIG_JSON`  | JSON string with embedder options (Phase 2+). |
+
+## Configuration Schema
+
+Overrides flow straight into the `llm` / `embedder` blocks that Mem0 expects.
+The service merges JSON snippets with the YAML defaults, so any provider listed
+in the official Mem0 matrix can be configured as follows:
+
+```json
+{
+  "llm": {
+    "provider": "<provider-name>",
+    "config": {
+      "model": "<model-id>",
+      "api_key": "...",
+      "base_url": "..."
+    }
+  },
+  "embedder": {
+    "provider": "<provider-name>",
+    "config": {
+      "model": "<embedding-model>",
+      "...": "..."
+    }
+  }
+}
+```
+
+`MEM0_LLM_PROVIDER` / `MEM0_EMBEDDER_PROVIDER` set the `provider` fields, while
+the `*_CONFIG_JSON` variables merge into the nested `config` objects. Any keys
+allowed by Mem0 (for example `ollama_base_url`, `deepseek_base_url`,
+`aws_region`) can be supplied.
 
 ## Provider Highlights
 

--- a/docs/env-mem0-providers.md
+++ b/docs/env-mem0-providers.md
@@ -1,0 +1,87 @@
+# Mem0 Provider Environment Quick Reference
+
+This guide summarises the environment variables you may need when switching the
+long-term memory service to different Mem0 providers. The information is based
+on the latest Mem0 documentation (Context7 `/mem0ai/mem0`, sections "Supported
+LLM Providers" and "Supported Embedding Providers"). Any provider on those
+lists can be used; the table below covers the ones we expect operators to reach
+for most often.
+
+> Tip: keep secrets in your preferred secret manager or Docker/Compose `.env`
+overrides instead of editing tracked files.
+
+## Core Variables
+
+| Purpose                | Variable                     | Notes |
+|------------------------|------------------------------|-------|
+| Mem0 API key (Cloud)   | `MEM0_API_KEY`               | Required for Mem0 Cloud users. Not needed for self-hosted Mem0. |
+| Base config path       | `MEM0_CONFIG_PATH`           | Defaults to `config/mem0_config.yaml`. Set when mounting a custom config. |
+| LLM provider override  | `MEM0_LLM_PROVIDER`          | Will be consumed once Phase 2 introduces runtime overrides. |
+| LLM config JSON        | `MEM0_LLM_CONFIG_JSON`       | JSON string with provider-specific options (Phase 2). |
+| Embedder provider      | `MEM0_EMBEDDER_PROVIDER`     | Used together with `MEM0_LLM_PROVIDER`. |
+| Embedder config JSON   | `MEM0_EMBEDDER_CONFIG_JSON`  | JSON string with embedder options (Phase 2). |
+
+## Provider Highlights
+
+| Provider   | Scope     | Required Variables / Notes |
+|------------|-----------|-----------------------------|
+| OpenAI     | LLM + Emb | `OPENAI_API_KEY`, optional `OPENAI_BASE_URL`, choose model via `MEM0_LLM_CONFIG_JSON` (e.g. `{ "model": "gpt-4o-mini" }`). |
+| Anthropic  | LLM       | `ANTHROPIC_API_KEY`; Mem0 config expects model name such as `claude-3-5-sonnet-20240620`. |
+| Gemini     | LLM/Emb   | `GOOGLE_API_KEY`; specify `model` (e.g. `models/gemini-1.5-pro-latest` for LLM or `models/text-embedding-004` for embeddings). |
+| DeepSeek   | LLM       | `DEEPSEEK_API_KEY` and optionally `DEEPSEEK_BASE_URL` for self-hosted gateways. |
+| xAI        | LLM       | `XAI_API_KEY`; include `xai_api_base` if using a non-default endpoint. |
+| Azure OpenAI | LLM/Emb | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT`. Mem0 supports both text and embedding deployments. |
+| AWS Bedrock | LLM/Emb  | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and region variables recognised by the AWS SDK. Model IDs go into the Mem0 config JSON. |
+| Groq       | LLM       | `GROQ_API_KEY`; typical models include `mixtral-8x7b-32768`. |
+| Together   | LLM/Emb   | `TOGETHER_API_KEY`; specify `model` in the config JSON. |
+| HuggingFace | Emb      | `HUGGINGFACEHUB_API_TOKEN` (if using gated models); set `model` to desired transformer name. |
+| Ollama     | LLM/Emb   | No API key. Ensure `OLLAMA_HOST` or include `ollama_base_url` in the config JSON (default `http://localhost:11434`). |
+| LM Studio  | LLM/Emb   | No API key. Provide the local server URL via `LMSTUDIO_BASE_URL` (default `http://localhost:1234`). |
+| Vertex AI  | Emb       | `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service account JSON; configure `model` such as `text-embedding-004`. |
+
+## Example Snippets
+
+### OpenAI (default)
+
+```
+export OPENAI_API_KEY="sk-..."
+export MEM0_LLM_PROVIDER="openai"
+export MEM0_LLM_CONFIG_JSON='{"model": "gpt-4o-mini", "temperature": 0.1}'
+export MEM0_EMBEDDER_PROVIDER="openai"
+export MEM0_EMBEDDER_CONFIG_JSON='{"model": "text-embedding-3-small"}'
+```
+
+### Anthropic + OpenAI Embeddings
+
+```
+export ANTHROPIC_API_KEY="sk-ant-..."
+export OPENAI_API_KEY="sk-openai-..."
+export MEM0_LLM_PROVIDER="anthropic"
+export MEM0_LLM_CONFIG_JSON='{"model": "claude-3-5-sonnet-20240620"}'
+export MEM0_EMBEDDER_PROVIDER="openai"
+export MEM0_EMBEDDER_CONFIG_JSON='{"model": "text-embedding-3-small"}'
+```
+
+### Local Ollama
+
+```
+export MEM0_LLM_PROVIDER="ollama"
+export MEM0_LLM_CONFIG_JSON='{"model": "llama3.1", "ollama_base_url": "http://localhost:11434"}'
+export MEM0_EMBEDDER_PROVIDER="ollama"
+export MEM0_EMBEDDER_CONFIG_JSON='{"model": "all-minilm:latest", "ollama_base_url": "http://localhost:11434"}'
+```
+
+### LM Studio LLM + Gemini Embeddings
+
+```
+export LMSTUDIO_BASE_URL="http://localhost:1234"
+export MEM0_LLM_PROVIDER="lmstudio"
+export MEM0_LLM_CONFIG_JSON='{"model": "lmstudio-community/Qwen2.5-7B-Instruct", "base_url": "http://localhost:1234"}'
+export GOOGLE_API_KEY="..."
+export MEM0_EMBEDDER_PROVIDER="gemini"
+export MEM0_EMBEDDER_CONFIG_JSON='{"model": "models/text-embedding-004"}'
+```
+
+Keep this document alongside `docs/ltm-multi-provider-plan.md` and update it
+whenever new providers are adopted or Mem0 introduces additional configuration
+options.

--- a/docs/ltm-multi-provider-plan.md
+++ b/docs/ltm-multi-provider-plan.md
@@ -1,0 +1,67 @@
+# Long-Term Memory Multi-Provider Enablement Plan
+
+## 1. Goals
+- Let the Mem0-backed long-term memory (LTM) service run against the full set of LLM providers supported by Mem0 (19 options such as OpenAI, Anthropic, Gemini, DeepSeek, xAI, Ollama, LM Studio, Groq, Bedrock, Azure OpenAI, etc.).
+- Offer embedding provider flexibility across all Mem0-supported embedders (10 options, e.g. OpenAI, HuggingFace, Gemini, Ollama, LM Studio, Vertex AI, Together, Bedrock, Azure OpenAI).
+- Keep configuration driven and easy to override so deployers can pick providers per environment without editing source files.
+- Preserve existing Redis queue interfaces and response payloads.
+
+## 2. Reference: Mem0 Provider Matrix
+The latest Mem0 documentation (Context7 `/mem0ai/mem0`, sections "Supported LLM Providers" and "Supported Embedding Providers") enumerates 19 LLM backends and 10 embedding backends. Rather than narrowing that list, we plan to expose configuration hooks so the LTM service can leverage **any** provider Mem0 supports. Mem0 already exposes provider-specific configuration blocks (`llm.config` and `embedder.config`) with keys such as `model`, `api_key`, `temperature`, `base_url`, or provider-specific parameters (`ollama_base_url`, `deepseek_base_url`, etc.). Our work is to surface these options in a user-friendly way.
+
+## 3. Current State Snapshot
+- `services/long-term-memory-python/config/config.json` pins the LTM service to OpenAI LLM + pgvector via `/app/config/mem0_config.yaml`.
+- `config/mem0_config.yaml` only describes OpenAI for both LLM and embeddings.
+- `Mem0Service` (`src/core/mem0_client.py`) loads a single config path and does not expose a way to override provider settings at runtime.
+- Environment management (`ConfigLoader`) offers a single `MEM0_CONFIG_PATH` override; no fine-grained toggles per provider.
+- Tests rely on mocked `Memory.from_config`, so adding providers should not break unit suites if the configuration surface is backward compatible.
+
+## 4. Implementation Plan
+### Phase 1 — Configuration Refactor
+1. Replace `config/mem0_config.yaml` with a template that separates provider-agnostic defaults from provider-specific examples.
+2. Introduce a new `docs/env-mem0-providers.md` or enrich `.env.example` to document the required environment variables for representative providers (API keys, base URLs) while explaining how to extend to any other Mem0 provider.
+3. Extend the JSON config (`config/config.json`) to include optional maps, e.g.:
+   ```json
+   "mem0": {
+     "config_path": "/app/config/mem0_config.yaml",
+     "llm_provider": "openai",
+     "embedding_provider": "openai"
+   }
+   ```
+   These keys allow the service to select a provider without hand-editing the YAML.
+
+### Phase 2 — Dynamic Mem0 Client Initialization
+1. Update `Mem0Service._ensure_client` to merge runtime overrides before calling `Memory.from_config`:
+   - Load the base YAML/JSON config.
+   - Overlay `llm.provider`, `embedder.provider`, and their `config` dictionaries if environment variables or JSON fields specify them.
+2. Accept provider-specific JSON payloads via environment variables, e.g. `MEM0_LLM_CONFIG_JSON` and `MEM0_EMBEDDER_CONFIG_JSON`, to avoid duplicating YAML files for each provider.
+3. Validate that the selected providers are in the Mem0-supported list (helpful error messages) and design the validation to stay aligned with future Mem0 releases.
+
+### Phase 3 — Provider-Specific Support
+1. Surface a generic configuration schema that maps directly onto Mem0's `llm` and `embedder` blocks (provider string + arbitrary nested `config`), avoiding hard-coded branches per provider in application code.
+2. Provide documentation tables that list common providers (OpenAI, Anthropic, Gemini, DeepSeek, xAI, Ollama, LM Studio, Groq, AWS Bedrock, Azure OpenAI, Together, etc.) with their required keys/base URLs, while clarifying that any other Mem0 provider can be supplied using the same mechanism.
+3. Update Docker Compose and `.env.example` with representative environment variable placeholders (e.g. `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`, `MEM0_OLLAMA_BASE_URL`, `AWS_ACCESS_KEY_ID`, `GOOGLE_API_KEY`) and guidance on extending the list as needed.
+
+### Phase 4 — Testing & Validation
+1. Expand unit tests to cover configuration merging logic (mock `Memory.from_config` to assert correct provider injection).
+2. Add parametrized tests for each provider override to ensure no key collisions.
+3. Spin up selective integration checks using local providers where feasible:
+   - Ollama + LM Studio have local stories; provide manual instructions in the docs for developers.
+4. Ensure existing tests remain green (mock-based). Where network calls are impossible, confirm exceptions surface clear "missing API key" messages.
+
+### Phase 5 — Documentation & Rollout
+1. Write operator documentation (in `docs/`) explaining how to enable each provider with sample environment blocks and expected prerequisites.
+2. Update changelog / release notes highlighting multi-provider capability.
+3. Coordinate with DevOps to provision secrets (Anthropic, DeepSeek, xAI) and to expose required ports for local providers.
+
+## 5. Risk & Mitigations
+- **Misconfiguration**: Mitigate by validating provider names against the Mem0 supported set and logging helpful tips.
+- **Secret sprawl**: Centralize environment variable names, encourage secret managers rather than files.
+- **Local provider latency / availability**: For Ollama or LM Studio, document health checks and timeouts inside the service.
+- **Inconsistent embedding dimensions**: When switching models, ensure downstream vector store (pgvector) accepts matching dimensions; plan schema migration or dynamic column sizing if needed.
+
+## 6. Deliverables
+- Updated configuration artifacts (`config.json`, `mem0_config.yaml`, `.env.example`, Docker compose environment section).
+- Enhanced `Mem0Service` initialization with provider injection and validation.
+- Tests covering configuration pathways.
+- Documentation for operators and developers (this plan + provider setup guide).

--- a/services/long-term-memory-python/config/config.json
+++ b/services/long-term-memory-python/config/config.json
@@ -10,7 +10,11 @@
     "db": 0
   },
   "mem0": {
-    "config_path": "/app/config/mem0_config.yaml"
+    "config_path": "/app/config/mem0_config.yaml",
+    "llm_provider": null,
+    "llm_config": {},
+    "embedding_provider": null,
+    "embedding_config": {}
   },
   "pgvector": {
     "host": "localhost",

--- a/services/long-term-memory-python/config/mem0_config.yaml
+++ b/services/long-term-memory-python/config/mem0_config.yaml
@@ -1,5 +1,10 @@
 version: v1.1
 
+# Base Mem0 configuration used by the long-term memory service.
+# Phase 2 will merge runtime overrides so any provider supported by Mem0 can
+# replace the values below without editing this file. Until then, these
+# defaults keep the existing OpenAI + pgvector behaviour.
+
 llm:
   provider: openai
   config:
@@ -20,3 +25,32 @@ vector_store:
     user: ltm_user
     password: ltm_password
     table_name: ltm_embeddings
+
+# -----------------------------------------------------------------------------
+# Provider examples (informational only — copy into overrides if needed):
+#
+# Anthropic LLM
+# llm:
+#   provider: anthropic
+#   config:
+#     model: claude-3-5-sonnet-20240620
+#     api_key: ${ANTHROPIC_API_KEY}
+#
+# Gemini Embeddings
+# embedder:
+#   provider: gemini
+#   config:
+#     model: models/text-embedding-004
+#     api_key: ${GOOGLE_API_KEY}
+#
+# Ollama Local Models
+# llm:
+#   provider: ollama
+#   config:
+#     model: llama3.1
+#     ollama_base_url: http://localhost:11434
+# embedder:
+#   provider: ollama
+#   config:
+#     model: all-minilm:latest
+#

--- a/services/long-term-memory-python/requirements.txt
+++ b/services/long-term-memory-python/requirements.txt
@@ -9,6 +9,7 @@ pydantic>=2.0.0
 openai>=1.0.0
 python-multipart>=0.0.6
 aiohttp>=3.9.0
+PyYAML>=6.0
 
 # 测试依赖
 pytest>=8.0.0

--- a/services/long-term-memory-python/src/core/mem0_client.py
+++ b/services/long-term-memory-python/src/core/mem0_client.py
@@ -373,7 +373,6 @@ class Mem0Service:
         base_config = self._load_base_config()
         overrides = self._collect_overrides()
         merged = self._apply_overrides(base_config, overrides)
-        self.logger.debug("Mem0最终配置: %s", merged)
         return merged
 
     def _load_base_config(self) -> Dict[str, Any]:

--- a/services/long-term-memory-python/src/utils/config_loader.py
+++ b/services/long-term-memory-python/src/utils/config_loader.py
@@ -2,11 +2,15 @@
 配置加载器
 """
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
+
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigLoader:
@@ -43,7 +47,30 @@ class ConfigLoader:
         
         # Mem0配置
         if "mem0" in config:
-            config["mem0"]["config_path"] = os.getenv("MEM0_CONFIG_PATH", config["mem0"]["config_path"])
+            mem0_cfg = config["mem0"]
+            mem0_cfg["config_path"] = os.getenv("MEM0_CONFIG_PATH", mem0_cfg.get("config_path"))
+
+            llm_provider = os.getenv("MEM0_LLM_PROVIDER")
+            if llm_provider:
+                mem0_cfg["llm_provider"] = llm_provider
+
+            embedder_provider = os.getenv("MEM0_EMBEDDER_PROVIDER")
+            if embedder_provider:
+                mem0_cfg["embedding_provider"] = embedder_provider
+
+            llm_cfg_raw = os.getenv("MEM0_LLM_CONFIG_JSON")
+            if llm_cfg_raw:
+                try:
+                    mem0_cfg["llm_config"] = json.loads(llm_cfg_raw)
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in MEM0_LLM_CONFIG_JSON; ignoring override")
+
+            embed_cfg_raw = os.getenv("MEM0_EMBEDDER_CONFIG_JSON")
+            if embed_cfg_raw:
+                try:
+                    mem0_cfg["embedding_config"] = json.loads(embed_cfg_raw)
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in MEM0_EMBEDDER_CONFIG_JSON; ignoring override")
         
         # 服务配置
         if "service" in config:


### PR DESCRIPTION
## Summary
- allow the long-term memory service to pull Mem0 LLM/embedder providers from JSON/env overrides
- document multi-provider usage, env variables, and compose knobs for operators
- add tests covering configuration merge logic and include PyYAML dependency

## Testing
- pytest (services/long-term-memory-python)
