### PR TITLE
feat(frontend): use relative ws endpoints with dev proxy

### DIFF
--- a/front_end/vite.config.js
+++ b/front_end/vite.config.js
@@ -33,5 +33,16 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: 'ws://127.0.0.1:8000',
+        changeOrigin: true,
+        ws: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy /api and /ws to the gateway
- build websocket endpoints from origin or VITE_WS_* vars to drop hard-coded ports

## Testing
- not run