### PR TITLE
feat: add dialog-engine audio pipeline

### DIFF
--- a/docs/dialog-engine-audio-asr-plan.md
+++ b/docs/dialog-engine-audio-asr-plan.md
@@ -128,6 +128,8 @@ Client -> /chat/audio (REST or WS) -> Audio Ingestor -> Preprocessor -> ASR Pipe
    - Add Postman/VSCode REST examples.
    - Provide migration notes explaining deprecation of old ASR/chat/tts services.
 
+   _Status_: ✅ README created with endpoint summary, environment variables, dependency list, curl/SSE examples, and migration notes covering the legacy ASR/chat/TTS retirement (`services/dialog-engine/README.md`).
+
 ## 9. Milestones
 1. **MVP (Week 1)**: `/chat/audio` sync endpoint with mock ASR provider, plumbing to chat pipeline, minimal tests.
 2. **Whisper Integration (Week 2)**: local model support, resource limits, SSE streaming with partials.
@@ -144,4 +146,3 @@ Client -> /chat/audio (REST or WS) -> Audio Ingestor -> Preprocessor -> ASR Pipe
 - Do we need diarization or word-level timestamps in MVP? (currently no, but interface leaves room in `AsrResult`.)
 - Should ASR operate in background tasks or run inline per request? (MVP inline, revisit when concurrency requirements known.)
 - Any compliance requirements for storing voice data? (Assume no persistent storage beyond temp files.)
-

--- a/docs/dialog-engine-audio-asr-plan.md
+++ b/docs/dialog-engine-audio-asr-plan.md
@@ -1,0 +1,147 @@
+# Dialog Engine Audio Input & ASR Integration Plan
+
+## 1. Background
+- `dialog-engine` currently streams LLM text replies and synchronous TTS output but only accepts text input.
+- Legacy standalone services (`asr-python`, `chat-ai-python`, `tts-python`) are being retired; the new flow must live entirely in `dialog-engine`.
+- Goal: allow clients to send raw audio, perform automatic speech recognition (ASR) inside `dialog-engine`, and feed recognized text into the existing conversation pipeline.
+
+## 2. Objectives
+1. Accept audio input (file upload and low-latency stream) alongside existing text API.
+2. Run ASR in-process with configurable providers (local Whisper/FunASR, cloud API, mock for tests).
+3. Convert ASR output into conversation turns, preserving memory interactions and downstream TTS hooks.
+4. Provide clear telemetry, error handling, and configuration knobs for production readiness.
+
+## 3. Scope
+- `dialog-engine` service only: new modules, endpoints, and docs.
+- Audio formats: 16 kHz mono PCM WAV (primary), with automatic resampling for common alternatives (48 kHz, stereo).
+- ASR providers: built-in `whisper` (local GPU/CPU), `mock` provider, pluggable interface for future services.
+- Out of scope: maintaining compatibility with removed microservices, front-end recording UI implementation, or cross-service redis messaging.
+
+## 4. High-Level Architecture
+```
+Client -> /chat/audio (REST or WS) -> Audio Ingestor -> Preprocessor -> ASR Pipeline -┐
+                                                                            └> ChatService.stream_reply -> SSE/WebSocket reply
+```
+
+### Components
+1. **Audio Ingestor** (`audio_ingest.py`)
+   - Validates request, enforces size/duration limits, and stores audio temporarily (memory or `/tmp`).
+   - Supports both multipart upload (`audio` file) and base64 JSON payloads.
+   - For streaming, wraps FastAPI WebSocket endpoint forwarding PCM chunks into an asyncio queue.
+
+2. **Audio Preprocessor** (`audio_preprocessor.py`)
+   - Normalizes sample rate/channels via `soundfile` + `resampy`/`librosa` or `ffmpeg-python` (configurable).
+   - Generates uniform NumPy float32 PCM ready for ASR providers.
+   - Provides metadata (duration, energy) for logging and guardrails.
+
+3. **ASR Service** (`asr_service.py`)
+   - Defines `class AsrProvider(Protocol)` with `async def transcribe(audio: AudioBatch, options: AsrOptions) -> AsrResult`.
+   - Implements providers:
+     - `MockAsrProvider`: deterministic text for tests.
+     - `WhisperAsrProvider`: wraps `openai-whisper` or `faster-whisper` local model with batching/timeout.
+   - Handles streaming mode by yielding `AsrPartial` deltas before final transcript.
+
+4. **Conversation Bridge**
+   - Extends `chat_service.ChatService` entrypoint to accept `AudioInput` struct.
+   - Writes ASR transcript into `ShortTermMemoryStore` and optional LTM outbox events before generating reply.
+
+5. **Response Streamer**
+   - Merges ASR partials and LLM deltas in single SSE/WebSocket stream for client consumption.
+   - Event types: `asr-partial`, `asr-final`, `text-delta`, `done` (with stats: TTFT, ASR latency, tokens).
+
+## 5. API Surface
+
+### REST: `POST /chat/audio`
+- Body (multipart or JSON):
+  ```json
+  {
+    "sessionId": "uuid",
+    "audioFormat": "wav",
+    "sampleRate": 48000,
+    "lang": "auto|zh|en",
+    "audio": "<base64>"   // if JSON payload
+  }
+  ```
+- Response: immediate acknowledgement with job stats or final result when `mode=sync` (default).
+- Query params:
+  - `stream=false/true`: switch to SSE streaming endpoint.
+  - `mode=sync|async`: async returns task id for later retrieval (future extension).
+
+### SSE: `POST /chat/audio/stream`
+- Returns server-sent events combining ASR + LLM.
+- Breaker thresholds: client disconnect aborts ASR to save resources.
+
+### WebSocket: `/ws/chat/audio`
+- Bidirectional real-time path for low-latency voice conversations.
+- Protocol messages:
+  - `AUDIO_START`, `AUDIO_CHUNK`, `AUDIO_END` from client.
+  - `ASR_PARTIAL`, `ASR_FINAL`, `LLM_DELTA`, `TTS_READY` from server.
+
+## 6. Configuration
+- Extend `settings.py` with `AsrSettings`:
+  ```python
+  class AsrSettings(BaseModel):
+      enabled: bool = True
+      provider: str = Field(default="whisper", regex="^(mock|whisper|custom:.+)$")
+      max_duration_sec: int = 300
+      max_size_mb: int = 25
+      sample_rate: int = 16000
+      stream_buffer_ms: int = 500
+      device: str = "auto"  # cpu/cuda
+      whisper_model: str = "small"
+      language: str | None = None
+  ```
+- Allow env overrides (e.g., `ASR_PROVIDER`, `ASR_WHISPER_MODEL`, `ASR_MAX_DURATION_SEC`).
+- Add logging flags and metrics prefix `dialog_engine.asr.*`.
+
+## 7. Telemetry & Error Handling
+- Structured logs on start/end: include sessionId, audio duration, provider, latency, success flag.
+- Prometheus-compatible counters:
+  - `asr_requests_total`, `asr_failures_total`, `asr_latency_seconds`, `asr_partial_updates_total`.
+- Expose `/metrics` (if not already) or reuse existing instrumentation pipeline.
+- Graceful fallbacks: on ASR failure, return HTTP 502 with error code `ASR_FAILED`; allow clients to retry or fall back to text input.
+
+## 8. Implementation Steps
+1. **Scaffold modules**
+   - Create `dialog_engine/audio/` package with ingest, preprocessing, types.
+   - Create `dialog_engine/asr/` package with provider interfaces and mock implementation.
+2. **Synchronous path**
+   - Implement `/chat/audio` endpoint: request parsing, audio validation, call `AsrService.transcribe`, forward transcript to `ChatService.stream_reply`.
+   - Ensure response includes ASR + LLM stats.
+3. **Streaming path (SSE)**
+   - Add generator combining ASR partials (async queue) and LLM reply; share cancellation with client disconnect detection (reuse `request.is_disconnected()`).
+4. **Provider integrations**
+   - Ship `MockAsrProvider` default.
+   - Integrate local Whisper via `faster-whisper` (CPU) with caching; guard optional dependency import.
+5. **Resource management**
+   - Enforce max duration/size; reject large files early with `413 Payload Too Large`.
+   - Use temp files with automatic cleanup or in-memory BytesIO (for <5 MB).
+6. **Memory + Analytics**
+   - Record ASR transcript as `user` turn in short-term memory before LLM call.
+   - Extend outbox events: `AnalyticsAsrStats`, `LtmWriteRequested` with speech metadata if async ext enabled.
+7. **Testing**
+   - Unit tests for ingest, preprocessing, ASR mock, endpoint validation (`pytest` + FastAPI `AsyncClient`).
+   - Integration test using fixture audio -> ensures final SSE stream contains `asr-final` before `done`.
+   - Load test script (optional) to evaluate concurrency and CPU usage.
+8. **Documentation & Ops**
+   - Update README (`services/dialog-engine/README.md`) with new env vars, usage.
+   - Add Postman/VSCode REST examples.
+   - Provide migration notes explaining deprecation of old ASR/chat/tts services.
+
+## 9. Milestones
+1. **MVP (Week 1)**: `/chat/audio` sync endpoint with mock ASR provider, plumbing to chat pipeline, minimal tests.
+2. **Whisper Integration (Week 2)**: local model support, resource limits, SSE streaming with partials.
+3. **Real-Time WS (Week 3)**: WebSocket ingestion, partial-asr coalescing, concurrency hardening.
+4. **Production Hardening (Week 4)**: metrics, alerting, documentation, load test, feature flag rollout.
+
+## 10. Risks & Mitigations
+- **Model Download Size**: Whisper models large; allow configurable cache dir and document warm-up.
+- **Latency on CPU**: Provide `device` and `model` tunables; support GPU if available.
+- **Security**: Validate audio MIME/types, limit upload size, sanitize temp paths.
+- **Cancellation**: Ensure streaming cancellation propagates to ASR task to avoid leaked workers.
+
+## 11. Open Questions
+- Do we need diarization or word-level timestamps in MVP? (currently no, but interface leaves room in `AsrResult`.)
+- Should ASR operate in background tasks or run inline per request? (MVP inline, revisit when concurrency requirements known.)
+- Any compliance requirements for storing voice data? (Assume no persistent storage beyond temp files.)
+

--- a/services/dialog-engine/README.md
+++ b/services/dialog-engine/README.md
@@ -1,0 +1,78 @@
+# Dialog Engine Service
+
+FastAPI service that powers synchronous chat + audio flows. It now accepts raw audio, performs ASR in-process, and emits streaming replies and analytics events.
+
+## Endpoints
+
+- `POST /chat/stream` – existing text SSE endpoint.
+- `POST /chat/audio` – accepts base64 audio payloads, runs ASR, returns JSON transcript/reply.
+- `POST /chat/audio/stream` – SSE stream that emits `asr-partial`, `asr-final`, `text-delta`, and `done` events.
+- `POST /tts/mock` – helper for synchronous TTS testing (requires `SYNC_TTS_STREAMING=true`).
+
+### Example (Sync Audio)
+```bash
+curl -X POST http://localhost:8100/chat/audio \
+  -H "Content-Type: application/json" \
+  -d '{
+        "sessionId": "demo",
+        "audio": "<base64 wav>",
+        "lang": "zh",
+        "meta": {"turn": 1}
+      }'
+```
+
+### Example (Stream Audio)
+Use any SSE client (curl `-N`, Postman, or VS Code REST client) to hit `/chat/audio/stream`. SSE events arrive in this order:
+1. `asr-partial`/`asr-final` (with transcript text and optional confidence)
+2. `text-delta` (token chunks from the reply)
+3. `done` (final transcript, reply, latency statistics)
+
+## Environment Variables
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `ASR_ENABLED` | Toggle audio ingestion | `true` |
+| `ASR_PROVIDER` | `mock` or `whisper` | `mock` |
+| `ASR_MAX_BYTES` | Max audio payload size in bytes | `5242880` |
+| `ASR_MAX_DURATION_SECONDS` | Max audio duration | `300` |
+| `ASR_TARGET_SAMPLE_RATE` | Preprocessor output rate | `16000` |
+| `ASR_TARGET_CHANNELS` | Output channels | `1` |
+| `ASR_DEFAULT_LANG` | Fallback language tag | `None` |
+| `ASR_WHISPER_MODEL` | Model id for faster-whisper | `base` |
+| `ASR_WHISPER_DEVICE` | `auto`, `cpu`, or `cuda` | `auto` |
+| `ASR_WHISPER_COMPUTE_TYPE` | e.g. `int8`, `float16` | `int8` |
+| `ASR_WHISPER_BEAM_SIZE` | Beam search width | `1` |
+| `ASR_WHISPER_CACHE_DIR` | Optional model cache path | unset |
+| `SYNC_TTS_STREAMING` | Enable `/tts/mock` audio push | `false` |
+| `ENABLE_ASYNC_EXT` | Enables outbox + analytics events | `false` |
+| `OUTPUT_INGEST_WS_URL` | Output handler WS endpoint | `ws://localhost:8002/ws/ingest/tts` |
+
+## Dependencies
+
+Install from `requirements.txt`:
+```bash
+pip install -r services/dialog-engine/requirements.txt
+```
+Includes `faster-whisper`, `numpy`, `soundfile`, `resampy` for audio preprocessing.
+
+## Testing
+
+```bash
+cd services/dialog-engine
+pytest tests/unit
+```
+
+Current unit coverage includes audio ingestion, ASR service wiring, memory/outbox behavior, and endpoint validation. Integration tests can be added once Redis and downstream services are available.
+
+## Migration Notes
+
+- Legacy microservices (`asr-python`, `chat-ai-python`, `tts-python`) are deprecated for audio input. `dialog-engine` owns ASR + chat orchestration.
+- Short-term memory database now records audio-derived turns (`remember_turn`). Ensure `STM_DB_PATH` persists across restarts if chat history is required.
+- Analytics outbox emits `AnalyticsAsrStats` alongside existing chat events; configure Redis streams consumers accordingly.
+
+## Tooling
+
+- Docker: `docker compose up -d` (see project root) to launch full stack.
+- Local dev: `uvicorn dialog_engine.app:app --reload --port 8100` (requires env vars).
+- Postman/VS Code REST: import the above examples and adjust `audio` payload as needed (WAV base64).
+

--- a/services/dialog-engine/requirements.txt
+++ b/services/dialog-engine/requirements.txt
@@ -1,10 +1,14 @@
 edge-tts==7.2.1
 fastapi==0.114.2
+faster-whisper==1.0.3
 httpx==0.25.0
+numpy==1.26.4
 openai==1.7.2
 pytest==8.4.2
 pytest-asyncio==0.23.8
 pytest-mock==3.14.0
+resampy==0.4.3
+soundfile==0.12.1
 redis==5.0.1
 uvicorn[standard]==0.30.6
 websockets==12.0

--- a/services/dialog-engine/src/dialog_engine/__init__.py
+++ b/services/dialog-engine/src/dialog_engine/__init__.py
@@ -1,0 +1,3 @@
+"""Core dialog engine package."""
+
+__all__ = []

--- a/services/dialog-engine/src/dialog_engine/app.py
+++ b/services/dialog-engine/src/dialog_engine/app.py
@@ -1,24 +1,52 @@
 import asyncio
+import base64
+import binascii
 import json
+import logging
 import os
 import time
 from typing import AsyncGenerator, Dict, Any
 
 import redis.asyncio as redis
 
-from fastapi import FastAPI, Request, HTTPException, BackgroundTasks
-from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from .chat_service import ChatService
+from .audio import AudioIngestor, AudioPreprocessor, IngestLimits
+from .asr import AsrOptions, AsrService
 from .tts_streamer import stream_text as tts_stream_text
 from .ltm_outbox import add_event as outbox_add_event, start_flush_task as outbox_start_flush
 
 
 app = FastAPI()
 chat_service = ChatService()
+logger = logging.getLogger(__name__)
 SYNC_TTS_STREAMING = os.getenv("SYNC_TTS_STREAMING", "false").lower() in {"1", "true", "yes", "on"}
 ENABLE_ASYNC_EXT = os.getenv("ENABLE_ASYNC_EXT", "false").lower() in {"1", "true", "yes", "on"}
 _flush_task = None
+
+try:
+    from .settings import settings as runtime_settings
+except ImportError:  # pragma: no cover - defensive fallback
+    runtime_settings = None
+
+if runtime_settings is not None:
+    asr_cfg = getattr(runtime_settings, "asr", None)
+else:  # pragma: no cover - fallback defaults
+    asr_cfg = None
+
+_asr_enabled = bool(getattr(asr_cfg, "enabled", True))
+_ingest_limits = IngestLimits(
+    max_bytes=getattr(asr_cfg, "max_bytes", 5 * 1024 * 1024),
+    max_duration_seconds=float(getattr(asr_cfg, "max_duration_seconds", 300.0)),
+)
+audio_ingestor = AudioIngestor(limits=_ingest_limits)
+audio_preprocessor = AudioPreprocessor(
+    target_sample_rate=int(getattr(asr_cfg, "target_sample_rate", 16000)),
+    target_channels=int(getattr(asr_cfg, "target_channels", 1)),
+)
+asr_service = AsrService()
 
 
 @app.get("/health")
@@ -29,6 +57,8 @@ async def health() -> Dict[str, Any]:
         "version": "m3-pre",
         "async_ext": ENABLE_ASYNC_EXT,
         "tts_provider": os.getenv("SYNC_TTS_PROVIDER", "mock"),
+        "asr_enabled": _asr_enabled,
+        "asr_provider": asr_service.provider.name if _asr_enabled else None,
     }
 
 
@@ -103,6 +133,101 @@ async def chat_stream(request: Request) -> StreamingResponse:
 
     headers = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
     return StreamingResponse(event_generator(), media_type="text/event-stream", headers=headers)
+
+
+@app.post("/chat/audio")
+async def chat_audio(request: Request) -> JSONResponse:
+    if not _asr_enabled:
+        raise HTTPException(status_code=503, detail="audio input disabled")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid json")
+
+    session_id = str(body.get("sessionId") or "default")
+    raw_audio = body.get("audio")
+    if not isinstance(raw_audio, str) or not raw_audio:
+        raise HTTPException(status_code=400, detail="audio required")
+
+    content_type = body.get("contentType") or "audio/wav"
+    lang = body.get("lang")
+    meta = body.get("meta") or {}
+
+    try:
+        audio_bytes = base64.b64decode(raw_audio, validate=True)
+    except (binascii.Error, TypeError):
+        raise HTTPException(status_code=400, detail="invalid audio encoding")
+
+    try:
+        payload = await audio_ingestor.from_bytes(
+            data=audio_bytes,
+            content_type=content_type,
+            meta={"lang": lang} if lang else None,
+        )
+    except ValueError:
+        raise HTTPException(status_code=413, detail="audio payload too large")
+
+    bundle = await audio_preprocessor.normalize(payload)
+
+    asr_started = time.perf_counter()
+    asr_options = AsrOptions(lang=lang or getattr(asr_cfg, "default_lang", None))
+    try:
+        asr_result = await asr_service.transcribe_bundle(bundle, options=asr_options)
+    except Exception as exc:  # pragma: no cover - provider errors converted to HTTP layer
+        logger.exception("chat.audio.asr_failed", extra={"sessionId": session_id})
+        raise HTTPException(status_code=502, detail="asr_failed") from exc
+
+    asr_completed = time.perf_counter()
+    asr_latency_ms = (asr_completed - asr_started) * 1000.0
+    transcript = (asr_result.text or "").strip()
+    if not transcript:
+        raise HTTPException(status_code=502, detail="empty transcript")
+
+    meta = dict(meta)
+    if lang and not meta.get("lang"):
+        meta["lang"] = lang
+    meta.setdefault("input_mode", "audio")
+    meta.setdefault("source", "asr")
+
+    reply_segments: list[str] = []
+    try:
+        async for delta in chat_service.stream_reply(session_id=session_id, user_text=transcript, meta=meta):
+            reply_segments.append(delta)
+    except Exception as exc:  # pragma: no cover - guard downstream failures
+        logger.exception("chat.audio.reply_failed", extra={"sessionId": session_id})
+        raise HTTPException(status_code=502, detail="chat_failed") from exc
+
+    reply_completed = time.perf_counter()
+    reply_text = "".join(reply_segments)
+
+    stats = {
+        "asr": {
+            "provider": asr_result.provider or asr_service.provider.name,
+            "latency_ms": round(asr_latency_ms, 1),
+            "duration_seconds": asr_result.duration_seconds,
+        },
+        "chat": {
+            "ttft_ms": round(chat_service.last_ttft_ms or 0.0, 1)
+            if chat_service.last_ttft_ms is not None
+            else None,
+            "tokens": chat_service.last_token_count,
+            "latency_ms": round((reply_completed - asr_completed) * 1000.0, 1),
+        },
+        "total_latency_ms": round((reply_completed - asr_started) * 1000.0, 1),
+    }
+
+    response_payload: Dict[str, Any] = {
+        "sessionId": session_id,
+        "transcript": transcript,
+        "reply": reply_text,
+        "stats": stats,
+    }
+
+    if asr_result.partials:
+        response_payload["partials"] = [partial.text for partial in asr_result.partials]
+
+    return JSONResponse(response_payload)
 
 
 @app.post("/tts/mock")

--- a/services/dialog-engine/src/dialog_engine/asr/__init__.py
+++ b/services/dialog-engine/src/dialog_engine/asr/__init__.py
@@ -1,0 +1,6 @@
+"""ASR scaffolding for dialog-engine."""
+
+from .service import AsrService
+from .types import AsrOptions, AsrPartial, AsrResult
+
+__all__ = ["AsrService", "AsrOptions", "AsrPartial", "AsrResult"]

--- a/services/dialog-engine/src/dialog_engine/asr/providers/__init__.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/__init__.py
@@ -3,4 +3,15 @@
 from .base import AsrProvider
 from .mock import MockAsrProvider
 
-__all__ = ["AsrProvider", "MockAsrProvider"]
+try:
+    from .whisper import WhisperAsrProvider
+except RuntimeError:  # pragma: no cover - optional dependency missing
+    WhisperAsrProvider = None  # type: ignore[assignment]
+except Exception:  # pragma: no cover - defensive guard
+    WhisperAsrProvider = None  # type: ignore[assignment]
+
+__all__ = [
+    "AsrProvider",
+    "MockAsrProvider",
+    "WhisperAsrProvider",
+]

--- a/services/dialog-engine/src/dialog_engine/asr/providers/__init__.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/__init__.py
@@ -1,0 +1,6 @@
+"""ASR provider implementations."""
+
+from .base import AsrProvider
+from .mock import MockAsrProvider
+
+__all__ = ["AsrProvider", "MockAsrProvider"]

--- a/services/dialog-engine/src/dialog_engine/asr/providers/base.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import abc
+from typing import AsyncGenerator
+
+from ..types import AsrOptions, AsrPartial, AsrResult
+
+
+class AsrProvider(abc.ABC):
+    """Interface for ASR providers."""
+
+    name: str
+
+    async def stream(self, *, audio: bytes, options: AsrOptions) -> AsyncGenerator[AsrPartial, None]:
+        result = await self.transcribe(audio=audio, options=options)
+        for partial in result.partials or []:
+            yield partial
+        yield AsrPartial(text=result.text)
+
+    @abc.abstractmethod
+    async def transcribe(self, *, audio: bytes, options: AsrOptions) -> AsrResult:
+        """Produce a transcription for the provided audio."""
+        raise NotImplementedError

--- a/services/dialog-engine/src/dialog_engine/asr/providers/mock.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/mock.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ..types import AsrOptions, AsrPartial, AsrResult
+from .base import AsrProvider
+
+
+class MockAsrProvider(AsrProvider):
+    name = "mock"
+
+    async def transcribe(self, *, audio: bytes, options: AsrOptions) -> AsrResult:
+        text = "mock transcription"
+        return AsrResult(text=text, partials=[AsrPartial(text=text)])

--- a/services/dialog-engine/src/dialog_engine/asr/providers/mock.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/mock.py
@@ -9,4 +9,4 @@ class MockAsrProvider(AsrProvider):
 
     async def transcribe(self, *, audio: bytes, options: AsrOptions) -> AsrResult:
         text = "mock transcription"
-        return AsrResult(text=text, partials=[AsrPartial(text=text)])
+        return AsrResult(text=text, partials=[AsrPartial(text=text, is_final=True)])

--- a/services/dialog-engine/src/dialog_engine/asr/providers/whisper.py
+++ b/services/dialog-engine/src/dialog_engine/asr/providers/whisper.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import threading
+from typing import Iterable, Optional
+
+from ..types import AsrOptions, AsrPartial, AsrResult
+from .base import AsrProvider
+
+try:  # pragma: no cover - optional dependency
+    from faster_whisper import WhisperModel
+except Exception:  # pragma: no cover - guard for environments without faster-whisper
+    WhisperModel = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - guard numpy import
+    np = None  # type: ignore[assignment]
+
+
+class WhisperAsrProvider(AsrProvider):
+    """ASR provider backed by faster-whisper."""
+
+    name = "whisper"
+
+    def __init__(
+        self,
+        *,
+        model: str = "base",
+        device: str = "auto",
+        compute_type: str = "int8",
+        beam_size: int = 1,
+        temperature: float = 0.0,
+        cache_dir: Optional[str] = None,
+        default_sample_rate: int = 16000,
+    ) -> None:
+        if WhisperModel is None:
+            raise RuntimeError("faster-whisper must be installed to use WhisperAsrProvider")
+        if np is None:
+            raise RuntimeError("numpy must be installed to use WhisperAsrProvider")
+
+        self._model_name = model
+        self._device = device
+        self._compute_type = compute_type
+        self._beam_size = max(1, beam_size)
+        self._temperature = max(0.0, temperature)
+        self._cache_dir = cache_dir
+        self._default_sample_rate = default_sample_rate
+
+        self._model: WhisperModel | None = None
+        self._model_lock = threading.Lock()
+
+    async def transcribe(self, *, audio: bytes, options: AsrOptions) -> AsrResult:
+        language = options.lang
+        sample_rate = options.sample_rate or self._default_sample_rate
+        enable_timestamps = options.enable_timestamps
+
+        segments, info = await asyncio.to_thread(
+            self._run_transcribe,
+            audio,
+            sample_rate,
+            language,
+            enable_timestamps,
+        )
+
+        partials: list[AsrPartial] = []
+        text_parts: list[str] = []
+        for segment in segments:
+            segment_text = (segment.text or "").strip()
+            if not segment_text:
+                continue
+            text_parts.append(segment_text)
+            confidence = _estimate_segment_confidence(segment)
+            partials.append(AsrPartial(text=segment_text, confidence=confidence, is_final=False))
+
+        final_text = " ".join(text_parts).strip()
+        duration = getattr(info, "duration", None)
+
+        return AsrResult(
+            text=final_text,
+            partials=partials,
+            duration_seconds=duration,
+            provider=self.name,
+        )
+
+    def _run_transcribe(
+        self,
+        audio: bytes,
+        sample_rate: int,
+        language: Optional[str],
+        enable_timestamps: bool,
+    ) -> tuple[Iterable[object], object]:
+        model = self._ensure_model()
+        audio_array = self._pcm_to_float(audio, sample_rate)
+
+        segments, info = model.transcribe(
+            audio_array,
+            language=language,
+            beam_size=self._beam_size,
+            temperature=self._temperature,
+            without_timestamps=not enable_timestamps,
+            task="transcribe",
+        )
+        segments_list = list(segments)
+        return segments_list, info
+
+    def _ensure_model(self) -> WhisperModel:
+        if self._model is None:
+            with self._model_lock:
+                if self._model is None:
+                    self._model = WhisperModel(
+                        self._model_name,
+                        device=self._device,
+                        compute_type=self._compute_type,
+                        cache_directory=self._cache_dir,
+                    )
+        return self._model
+
+    def _pcm_to_float(self, pcm_bytes: bytes, sample_rate: int) -> "np.ndarray":
+        if not pcm_bytes:
+            return np.zeros(0, dtype=np.float32)
+        pcm_array = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32)
+        # Normalize 16-bit PCM to [-1, 1]
+        pcm_array /= 32768.0
+        return pcm_array
+
+
+def _estimate_segment_confidence(segment: object) -> Optional[float]:
+    """Derive a rough confidence estimate from whisper segment metadata."""
+
+    avg_logprob = getattr(segment, "avg_logprob", None)
+    no_speech_prob = getattr(segment, "no_speech_prob", None)
+    if avg_logprob is None and no_speech_prob is None:
+        return None
+
+    confidence = 0.0
+    if avg_logprob is not None:
+        # avg_logprob typically ranges [-5, 0]; map to [0, 1]
+        confidence = 1.0 - math.exp(min(0.0, avg_logprob))
+    if no_speech_prob is not None:
+        confidence *= 1.0 - max(0.0, min(1.0, float(no_speech_prob)))
+    return max(0.0, min(1.0, confidence))

--- a/services/dialog-engine/src/dialog_engine/asr/service.py
+++ b/services/dialog-engine/src/dialog_engine/asr/service.py
@@ -5,7 +5,7 @@ from typing import Optional
 from ..audio import AudioBundle
 from .providers.base import AsrProvider
 from .providers.mock import MockAsrProvider
-from .types import AsrOptions, AsrResult
+from .types import AsrOptions, AsrPartial, AsrResult
 
 
 class AsrService:
@@ -16,7 +16,16 @@ class AsrService:
 
     async def transcribe_bundle(self, bundle: AudioBundle, *, options: Optional[AsrOptions] = None) -> AsrResult:
         opts = options or AsrOptions()
-        return await self._provider.transcribe(audio=bundle.pcm, options=opts)
+        result = await self._provider.transcribe(audio=bundle.pcm, options=opts)
+        partials = list(result.partials or [])
+        if not partials or not partials[-1].is_final:
+            partials.append(AsrPartial(text=result.text, is_final=True))
+        return AsrResult(
+            text=result.text,
+            partials=partials,
+            duration_seconds=result.duration_seconds,
+            provider=result.provider,
+        )
 
     @property
     def provider(self) -> AsrProvider:

--- a/services/dialog-engine/src/dialog_engine/asr/service.py
+++ b/services/dialog-engine/src/dialog_engine/asr/service.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from typing import Optional
 
 from ..audio import AudioBundle
+from ..settings import AsrSettings
 from .providers.base import AsrProvider
 from .providers.mock import MockAsrProvider
+
+try:
+    from .providers.whisper import WhisperAsrProvider
+except RuntimeError:  # pragma: no cover - optional dependency not available
+    WhisperAsrProvider = None  # type: ignore[assignment]
+except Exception:  # pragma: no cover - defensive guard
+    WhisperAsrProvider = None  # type: ignore[assignment]
 from .types import AsrOptions, AsrPartial, AsrResult
 
 
@@ -14,8 +22,31 @@ class AsrService:
     def __init__(self, *, provider: Optional[AsrProvider] = None) -> None:
         self._provider = provider or MockAsrProvider()
 
+    @classmethod
+    def from_settings(cls, cfg: AsrSettings | None) -> "AsrService":
+        provider: Optional[AsrProvider] = None
+        if cfg is not None:
+            provider_name = (cfg.provider or "mock").strip().lower()
+            if provider_name in {"mock", "fake"}:
+                provider = MockAsrProvider()
+            elif provider_name in {"whisper", "faster-whisper"}:
+                if WhisperAsrProvider is None:
+                    raise RuntimeError("Whisper provider selected but dependencies missing")
+                provider = WhisperAsrProvider(
+                    model=cfg.whisper_model,
+                    device=cfg.whisper_device,
+                    compute_type=cfg.whisper_compute_type,
+                    beam_size=cfg.whisper_beam_size,
+                    cache_dir=cfg.whisper_cache_dir,
+                    default_sample_rate=cfg.target_sample_rate,
+                )
+            else:
+                raise RuntimeError(f"unsupported ASR provider: {cfg.provider}")
+        return cls(provider=provider)
+
     async def transcribe_bundle(self, bundle: AudioBundle, *, options: Optional[AsrOptions] = None) -> AsrResult:
         opts = options or AsrOptions()
+        opts.sample_rate = opts.sample_rate or bundle.metadata.sample_rate
         result = await self._provider.transcribe(audio=bundle.pcm, options=opts)
         partials = list(result.partials or [])
         if not partials or not partials[-1].is_final:

--- a/services/dialog-engine/src/dialog_engine/asr/service.py
+++ b/services/dialog-engine/src/dialog_engine/asr/service.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ..audio import AudioBundle
+from .providers.base import AsrProvider
+from .providers.mock import MockAsrProvider
+from .types import AsrOptions, AsrResult
+
+
+class AsrService:
+    """Coordinates ASR provider usage."""
+
+    def __init__(self, *, provider: Optional[AsrProvider] = None) -> None:
+        self._provider = provider or MockAsrProvider()
+
+    async def transcribe_bundle(self, bundle: AudioBundle, *, options: Optional[AsrOptions] = None) -> AsrResult:
+        opts = options or AsrOptions()
+        return await self._provider.transcribe(audio=bundle.pcm, options=opts)
+
+    @property
+    def provider(self) -> AsrProvider:
+        return self._provider

--- a/services/dialog-engine/src/dialog_engine/asr/types.py
+++ b/services/dialog-engine/src/dialog_engine/asr/types.py
@@ -14,6 +14,7 @@ class AsrOptions:
 class AsrPartial:
     text: str
     confidence: Optional[float] = None
+    is_final: bool = False
 
 
 @dataclass(slots=True)

--- a/services/dialog-engine/src/dialog_engine/asr/types.py
+++ b/services/dialog-engine/src/dialog_engine/asr/types.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass(slots=True)
+class AsrOptions:
+    lang: Optional[str] = None
+    enable_timestamps: bool = False
+
+
+@dataclass(slots=True)
+class AsrPartial:
+    text: str
+    confidence: Optional[float] = None
+
+
+@dataclass(slots=True)
+class AsrResult:
+    text: str
+    partials: Iterable[AsrPartial] | None = None
+    duration_seconds: Optional[float] = None
+    provider: Optional[str] = None

--- a/services/dialog-engine/src/dialog_engine/asr/types.py
+++ b/services/dialog-engine/src/dialog_engine/asr/types.py
@@ -8,6 +8,7 @@ from typing import Iterable, Optional
 class AsrOptions:
     lang: Optional[str] = None
     enable_timestamps: bool = False
+    sample_rate: Optional[int] = None
 
 
 @dataclass(slots=True)

--- a/services/dialog-engine/src/dialog_engine/audio/__init__.py
+++ b/services/dialog-engine/src/dialog_engine/audio/__init__.py
@@ -1,0 +1,14 @@
+"""Audio ingestion and preprocessing scaffolding."""
+
+from .ingest import AudioIngestor, IngestLimits
+from .preprocessor import AudioPreprocessor
+from .types import AudioBundle, AudioMetadata, AudioPayload
+
+__all__ = [
+    "AudioIngestor",
+    "IngestLimits",
+    "AudioPreprocessor",
+    "AudioBundle",
+    "AudioMetadata",
+    "AudioPayload",
+]

--- a/services/dialog-engine/src/dialog_engine/audio/ingest.py
+++ b/services/dialog-engine/src/dialog_engine/audio/ingest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+from .types import AudioPayload
+
+
+@dataclass(slots=True)
+class IngestLimits:
+    max_bytes: int
+    max_duration_seconds: float
+
+
+class AudioIngestor:
+    """Parses inbound requests into AudioPayload objects."""
+
+    def __init__(self, *, limits: IngestLimits) -> None:
+        self._limits = limits
+
+    async def from_bytes(self, *, data: bytes, content_type: str, meta: Optional[dict[str, Any]] = None) -> AudioPayload:
+        self._enforce_size(len(data))
+        return AudioPayload(data=data, content_type=content_type, extra=meta or {})
+
+    async def from_upload(self, *, file_reader: Callable[[], Awaitable[bytes]], content_type: str, meta: Optional[dict[str, Any]] = None) -> AudioPayload:
+        data = await file_reader()
+        return await self.from_bytes(data=data, content_type=content_type, meta=meta)
+
+    def _enforce_size(self, size: int) -> None:
+        if size > self._limits.max_bytes:
+            raise ValueError("audio payload exceeds configured size limit")

--- a/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
+++ b/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
 
-from typing import Optional
+import io
+from typing import Optional, Tuple
+
+try:  # pragma: no cover - optional dependency guard
+    import numpy as np
+except Exception:  # pragma: no cover
+    np = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency guard
+    import soundfile as sf
+except Exception:  # pragma: no cover
+    sf = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency guard
+    import resampy
+except Exception:  # pragma: no cover
+    resampy = None  # type: ignore[assignment]
 
 from .types import AudioBundle, AudioMetadata, AudioPayload
 
@@ -8,24 +24,78 @@ from .types import AudioBundle, AudioMetadata, AudioPayload
 class AudioPreprocessor:
     """Normalizes audio data prior to ASR."""
 
-    def __init__(self, *, target_sample_rate: int = 16000, target_channels: int = 1) -> None:
+    def __init__(
+        self,
+        *,
+        target_sample_rate: int = 16000,
+        target_channels: int = 1,
+        max_duration_seconds: Optional[float] = None,
+    ) -> None:
         self._target_sample_rate = target_sample_rate
         self._target_channels = target_channels
+        self._max_duration_seconds = max_duration_seconds
 
     async def normalize(self, payload: AudioPayload) -> AudioBundle:
-        sample_rate = payload.sample_rate or self._target_sample_rate
-        channels = payload.channels or self._target_channels
-        duration = payload.duration_seconds
-        if duration is None or duration <= 0.0:
-            bytes_per_sample = max(1, channels) * 2  # assuming 16-bit PCM
-            if sample_rate > 0 and bytes_per_sample > 0:
+        pcm, sample_rate, channels = await self._extract_pcm(payload)
+        duration: float
+        if np is not None and pcm is not None:
+            if channels != self._target_channels:
+                pcm = self._mix_down(pcm, channels)
+                channels = self._target_channels
+            if sample_rate != self._target_sample_rate:
+                pcm, changed = self._resample(pcm, sample_rate, self._target_sample_rate)
+                if changed:
+                    sample_rate = self._target_sample_rate
+            duration = float(len(pcm)) / float(sample_rate) if sample_rate > 0 else 0.0
+            pcm_int16 = np.ascontiguousarray((pcm * 32768.0).clip(-32768, 32767).astype("<i2"))
+            pcm_bytes = pcm_int16.tobytes()
+        else:
+            # Fallback: assume incoming PCM already matches desired format
+            channels = payload.channels or self._target_channels
+            sample_rate = payload.sample_rate or self._target_sample_rate
+            if payload.duration_seconds and payload.duration_seconds > 0:
+                duration = float(payload.duration_seconds)
+            elif sample_rate > 0:
+                bytes_per_sample = max(1, channels) * 2
                 duration = len(payload.data) / float(sample_rate * bytes_per_sample)
             else:
                 duration = 0.0
+            pcm_bytes = payload.data
+
+        if self._max_duration_seconds and duration > self._max_duration_seconds:
+            raise ValueError("audio duration exceeds configured limit")
+
         metadata = AudioMetadata(
             sample_rate=sample_rate,
             channels=channels,
             duration_seconds=duration,
             format=payload.content_type,
         )
-        return AudioBundle(pcm=payload.data, metadata=metadata)
+        return AudioBundle(pcm=pcm_bytes, metadata=metadata)
+
+    async def _extract_pcm(self, payload: AudioPayload) -> Tuple["np.ndarray" | None, int, int]:
+        if np is None or sf is None:
+            return None, payload.sample_rate or self._target_sample_rate, payload.channels or self._target_channels
+        data = payload.data
+        if not data:
+            return np.zeros(0, dtype=np.float32), payload.sample_rate or self._target_sample_rate, self._target_channels
+        try:
+            audio_array, sample_rate = sf.read(io.BytesIO(data), dtype="float32")
+        except Exception as exc:  # pragma: no cover - propagates decode errors
+            raise ValueError("unsupported audio encoding") from exc
+        if audio_array.ndim == 1:
+            audio_array = audio_array[:, None]
+        channels = audio_array.shape[1]
+        return audio_array, int(sample_rate), channels
+
+    def _mix_down(self, pcm: "np.ndarray", channels: int) -> "np.ndarray":
+        if channels <= 1:
+            return pcm
+        return np.mean(pcm, axis=1, keepdims=True, dtype=np.float32).astype(np.float32)
+
+    def _resample(self, pcm: "np.ndarray", source_rate: int, target_rate: int) -> Tuple["np.ndarray", bool]:
+        if resampy is None or source_rate == target_rate or pcm.size == 0:
+            return pcm, False
+        pcm_flat = pcm[:, 0]
+        resampled = resampy.resample(pcm_flat, source_rate, target_rate)
+        return resampled[:, None].astype(np.float32), True

--- a/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
+++ b/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .types import AudioBundle, AudioMetadata, AudioPayload
+
+
+class AudioPreprocessor:
+    """Normalizes audio data prior to ASR."""
+
+    def __init__(self, *, target_sample_rate: int = 16000, target_channels: int = 1) -> None:
+        self._target_sample_rate = target_sample_rate
+        self._target_channels = target_channels
+
+    async def normalize(self, payload: AudioPayload) -> AudioBundle:
+        metadata = AudioMetadata(
+            sample_rate=payload.sample_rate or self._target_sample_rate,
+            channels=payload.channels or self._target_channels,
+            duration_seconds=payload.duration_seconds or 0.0,
+            format=payload.content_type,
+        )
+        return AudioBundle(pcm=payload.data, metadata=metadata)

--- a/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
+++ b/services/dialog-engine/src/dialog_engine/audio/preprocessor.py
@@ -13,10 +13,19 @@ class AudioPreprocessor:
         self._target_channels = target_channels
 
     async def normalize(self, payload: AudioPayload) -> AudioBundle:
+        sample_rate = payload.sample_rate or self._target_sample_rate
+        channels = payload.channels or self._target_channels
+        duration = payload.duration_seconds
+        if duration is None or duration <= 0.0:
+            bytes_per_sample = max(1, channels) * 2  # assuming 16-bit PCM
+            if sample_rate > 0 and bytes_per_sample > 0:
+                duration = len(payload.data) / float(sample_rate * bytes_per_sample)
+            else:
+                duration = 0.0
         metadata = AudioMetadata(
-            sample_rate=payload.sample_rate or self._target_sample_rate,
-            channels=payload.channels or self._target_channels,
-            duration_seconds=payload.duration_seconds or 0.0,
+            sample_rate=sample_rate,
+            channels=channels,
+            duration_seconds=duration,
             format=payload.content_type,
         )
         return AudioBundle(pcm=payload.data, metadata=metadata)

--- a/services/dialog-engine/src/dialog_engine/audio/types.py
+++ b/services/dialog-engine/src/dialog_engine/audio/types.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+
+@dataclass(slots=True)
+class AudioPayload:
+    """Raw audio payload supplied by clients."""
+
+    data: bytes
+    content_type: str
+    sample_rate: Optional[int] = None
+    channels: Optional[int] = None
+    duration_seconds: Optional[float] = None
+    extra: Mapping[str, str] | None = None
+
+
+@dataclass(slots=True)
+class AudioMetadata:
+    """Normalized metadata emitted by preprocessing."""
+
+    sample_rate: int
+    channels: int
+    duration_seconds: float
+    format: str
+
+
+@dataclass(slots=True)
+class AudioBundle:
+    """Preprocessed audio ready for ASR consumption."""
+
+    pcm: bytes
+    metadata: AudioMetadata

--- a/services/dialog-engine/src/dialog_engine/chat_service.py
+++ b/services/dialog-engine/src/dialog_engine/chat_service.py
@@ -118,6 +118,18 @@ class ChatService:
             await asyncio.sleep(0.02 + random.random() * 0.03)
             yield word + (" " if not word.endswith("\n") else "")
 
+    async def remember_turn(self, session_id: str, *, role: str, content: str) -> None:
+        if not content or not content.strip():
+            return
+        cfg = self._settings.short_term
+        if not cfg.enabled:
+            return
+        store = self._ensure_memory_store()
+        try:
+            await store.append_turn(session_id=session_id, role=role, content=content.strip())
+        except Exception as exc:  # pragma: no cover - best effort log
+            self._log_context_warning("stm.append.error", exc)
+
     async def _emit_with_metrics(
         self,
         generator: AsyncGenerator[str, None],

--- a/services/dialog-engine/src/dialog_engine/settings.py
+++ b/services/dialog-engine/src/dialog_engine/settings.py
@@ -73,11 +73,22 @@ class LTMInlineSettings:
 
 
 @dataclass(frozen=True)
+class AsrSettings:
+    enabled: bool
+    max_bytes: int
+    max_duration_seconds: float
+    target_sample_rate: int
+    target_channels: int
+    default_lang: str | None
+
+
+@dataclass(frozen=True)
 class Settings:
     openai: OpenAISettings
     llm: LLMSettings
     short_term: ShortTermMemorySettings
     ltm_inline: LTMInlineSettings
+    asr: AsrSettings
 
 
 def load_settings() -> Settings:
@@ -116,11 +127,21 @@ def load_settings() -> Settings:
         max_snippets=_env_int("LTM_MAX_SNIPPETS", 5),
     )
 
+    asr_settings = AsrSettings(
+        enabled=_env_bool("ASR_ENABLED", True),
+        max_bytes=_env_int("ASR_MAX_BYTES", 5 * 1024 * 1024),
+        max_duration_seconds=_env_float("ASR_MAX_DURATION_SECONDS", 300.0),
+        target_sample_rate=_env_int("ASR_TARGET_SAMPLE_RATE", 16000),
+        target_channels=_env_int("ASR_TARGET_CHANNELS", 1),
+        default_lang=os.getenv("ASR_DEFAULT_LANG"),
+    )
+
     return Settings(
         openai=openai_settings,
         llm=llm_settings,
         short_term=short_term_settings,
         ltm_inline=ltm_inline_settings,
+        asr=asr_settings,
     )
 
 
@@ -132,6 +153,7 @@ __all__ = [
     "OpenAISettings",
     "ShortTermMemorySettings",
     "LTMInlineSettings",
+    "AsrSettings",
     "settings",
     "load_settings",
 ]

--- a/services/dialog-engine/src/dialog_engine/settings.py
+++ b/services/dialog-engine/src/dialog_engine/settings.py
@@ -75,11 +75,17 @@ class LTMInlineSettings:
 @dataclass(frozen=True)
 class AsrSettings:
     enabled: bool
+    provider: str
     max_bytes: int
     max_duration_seconds: float
     target_sample_rate: int
     target_channels: int
     default_lang: str | None
+    whisper_model: str
+    whisper_device: str
+    whisper_compute_type: str
+    whisper_beam_size: int
+    whisper_cache_dir: str | None
 
 
 @dataclass(frozen=True)
@@ -129,11 +135,17 @@ def load_settings() -> Settings:
 
     asr_settings = AsrSettings(
         enabled=_env_bool("ASR_ENABLED", True),
+        provider=os.getenv("ASR_PROVIDER", "mock"),
         max_bytes=_env_int("ASR_MAX_BYTES", 5 * 1024 * 1024),
         max_duration_seconds=_env_float("ASR_MAX_DURATION_SECONDS", 300.0),
         target_sample_rate=_env_int("ASR_TARGET_SAMPLE_RATE", 16000),
         target_channels=_env_int("ASR_TARGET_CHANNELS", 1),
         default_lang=os.getenv("ASR_DEFAULT_LANG"),
+        whisper_model=os.getenv("ASR_WHISPER_MODEL", "base"),
+        whisper_device=os.getenv("ASR_WHISPER_DEVICE", "auto"),
+        whisper_compute_type=os.getenv("ASR_WHISPER_COMPUTE_TYPE", "int8"),
+        whisper_beam_size=_env_int("ASR_WHISPER_BEAM_SIZE", 1),
+        whisper_cache_dir=os.getenv("ASR_WHISPER_CACHE_DIR"),
     )
 
     return Settings(

--- a/services/dialog-engine/tests/unit/test_asr_service.py
+++ b/services/dialog-engine/tests/unit/test_asr_service.py
@@ -1,0 +1,37 @@
+import dataclasses
+
+import pytest
+
+from dialog_engine.asr.providers.mock import MockAsrProvider
+from dialog_engine.asr.service import AsrService
+from dialog_engine.settings import AsrSettings
+
+
+def _default_asr_settings() -> AsrSettings:
+    return AsrSettings(
+        enabled=True,
+        provider="mock",
+        max_bytes=1024 * 1024,
+        max_duration_seconds=300.0,
+        target_sample_rate=16000,
+        target_channels=1,
+        default_lang="zh",
+        whisper_model="base",
+        whisper_device="auto",
+        whisper_compute_type="int8",
+        whisper_beam_size=1,
+        whisper_cache_dir=None,
+    )
+
+
+def test_asr_service_from_settings_mock():
+    service = AsrService.from_settings(_default_asr_settings())
+
+    assert isinstance(service.provider, MockAsrProvider)
+
+
+def test_asr_service_from_settings_unknown_provider():
+    cfg = dataclasses.replace(_default_asr_settings(), provider="unknown")
+
+    with pytest.raises(RuntimeError):
+        AsrService.from_settings(cfg)

--- a/services/dialog-engine/tests/unit/test_audio_endpoints.py
+++ b/services/dialog-engine/tests/unit/test_audio_endpoints.py
@@ -4,6 +4,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dialog_engine import app as dialog_app
+from dialog_engine.asr.types import AsrPartial, AsrResult
+from dialog_engine.audio.types import AudioBundle, AudioMetadata
 
 
 @pytest.fixture
@@ -39,3 +41,89 @@ def test_chat_audio_returns_400_when_audio_invalid(monkeypatch, client):
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "unsupported audio"
+
+
+def _fake_bundle() -> AudioBundle:
+    return AudioBundle(
+        pcm=b"",
+        metadata=AudioMetadata(sample_rate=16000, channels=1, duration_seconds=0.5, format="audio/wav"),
+    )
+
+
+def _fake_asr_result() -> AsrResult:
+    return AsrResult(
+        text="你好",
+        partials=[AsrPartial(text="你好", is_final=True)],
+        duration_seconds=0.5,
+        provider="mock",
+    )
+
+
+def test_chat_audio_records_memory_and_events(monkeypatch, client):
+    recorded: list[tuple[str, str]] = []
+    events: list[dict] = []
+
+    async def fake_prepare(body):  # noqa: ANN001
+        return ("sess", _fake_bundle(), "zh", {})
+
+    async def fake_transcribe(bundle, options=None):  # noqa: ANN001
+        return _fake_asr_result()
+
+    async def fake_stream_reply(*, session_id: str, user_text: str, meta: dict):
+        yield "hello"
+
+    async def fake_remember(session_id: str, *, role: str, content: str) -> None:
+        recorded.append((role, content))
+
+    def fake_emit(**kwargs):
+        events.append(kwargs)
+
+    monkeypatch.setattr(dialog_app, "_prepare_audio_request", fake_prepare)
+    monkeypatch.setattr(dialog_app.asr_service, "transcribe_bundle", fake_transcribe)
+    monkeypatch.setattr(dialog_app.chat_service, "stream_reply", fake_stream_reply)
+    monkeypatch.setattr(dialog_app.chat_service, "remember_turn", fake_remember)
+    monkeypatch.setattr(dialog_app, "_emit_async_events", fake_emit)
+    monkeypatch.setattr(dialog_app, "ENABLE_ASYNC_EXT", True)
+
+    payload = {"sessionId": "sess", "audio": base64.b64encode(b"foo").decode("ascii")}
+    resp = client.post("/chat/audio", json=payload)
+
+    assert resp.status_code == 200
+    assert ("user", "你好") in recorded
+    assert ("assistant", "hello") in recorded
+    assert events and events[0]["transcript"] == "你好"
+
+
+def test_chat_audio_stream_records_memory(monkeypatch, client):
+    recorded: list[tuple[str, str]] = []
+    events: list[dict] = []
+
+    async def fake_prepare(body):  # noqa: ANN001
+        return ("sess", _fake_bundle(), "zh", {})
+
+    async def fake_transcribe(bundle, options=None):  # noqa: ANN001
+        return _fake_asr_result()
+
+    async def fake_stream_reply(*, session_id: str, user_text: str, meta: dict):
+        yield "hello"
+
+    async def fake_remember(session_id: str, *, role: str, content: str) -> None:
+        recorded.append((role, content))
+
+    def fake_emit(**kwargs):
+        events.append(kwargs)
+
+    monkeypatch.setattr(dialog_app, "_prepare_audio_request", fake_prepare)
+    monkeypatch.setattr(dialog_app.asr_service, "transcribe_bundle", fake_transcribe)
+    monkeypatch.setattr(dialog_app.chat_service, "stream_reply", fake_stream_reply)
+    monkeypatch.setattr(dialog_app.chat_service, "remember_turn", fake_remember)
+    monkeypatch.setattr(dialog_app, "_emit_async_events", fake_emit)
+    monkeypatch.setattr(dialog_app, "ENABLE_ASYNC_EXT", True)
+
+    payload = {"sessionId": "sess", "audio": base64.b64encode(b"foo").decode("ascii")}
+    with client.stream("POST", "/chat/audio/stream", json=payload) as resp:
+        list(resp.iter_content())
+
+    assert ("user", "你好") in recorded
+    assert ("assistant", "hello") in recorded
+    assert events and events[0]["transcript"] == "你好"

--- a/services/dialog-engine/tests/unit/test_audio_endpoints.py
+++ b/services/dialog-engine/tests/unit/test_audio_endpoints.py
@@ -122,7 +122,7 @@ def test_chat_audio_stream_records_memory(monkeypatch, client):
 
     payload = {"sessionId": "sess", "audio": base64.b64encode(b"foo").decode("ascii")}
     with client.stream("POST", "/chat/audio/stream", json=payload) as resp:
-        list(resp.iter_content())
+        list(resp.iter_text())
 
     assert ("user", "你好") in recorded
     assert ("assistant", "hello") in recorded

--- a/services/dialog-engine/tests/unit/test_audio_endpoints.py
+++ b/services/dialog-engine/tests/unit/test_audio_endpoints.py
@@ -1,0 +1,41 @@
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dialog_engine import app as dialog_app
+
+
+@pytest.fixture
+def client():
+    return TestClient(dialog_app.app)
+
+
+def test_chat_audio_returns_413_when_duration_exceeded(monkeypatch, client):
+    async def raise_duration_error(_body):
+        raise ValueError("duration limit exceeded")
+
+    monkeypatch.setattr(dialog_app, "_prepare_audio_request", raise_duration_error)
+
+    resp = client.post(
+        "/chat/audio",
+        json={"sessionId": "s", "audio": base64.b64encode(b"foo").decode("ascii")},
+    )
+
+    assert resp.status_code == 413
+    assert resp.json()["detail"] == "audio payload too large"
+
+
+def test_chat_audio_returns_400_when_audio_invalid(monkeypatch, client):
+    async def raise_format_error(_body):
+        raise ValueError("unsupported audio encoding")
+
+    monkeypatch.setattr(dialog_app, "_prepare_audio_request", raise_format_error)
+
+    resp = client.post(
+        "/chat/audio",
+        json={"sessionId": "s", "audio": base64.b64encode(b"foo").decode("ascii")},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "unsupported audio"

--- a/services/dialog-engine/tests/unit/test_audio_ingest.py
+++ b/services/dialog-engine/tests/unit/test_audio_ingest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from dialog_engine.audio.ingest import AudioIngestor, IngestLimits
+
+
+@pytest.mark.asyncio
+async def test_audio_ingestor_allows_within_limit():
+    ingestor = AudioIngestor(limits=IngestLimits(max_bytes=10, max_duration_seconds=60))
+
+    payload = await ingestor.from_bytes(data=b"12345", content_type="audio/wav")
+
+    assert payload.content_type == "audio/wav"
+    assert payload.data == b"12345"
+
+
+@pytest.mark.asyncio
+async def test_audio_ingestor_enforces_size_limit():
+    ingestor = AudioIngestor(limits=IngestLimits(max_bytes=3, max_duration_seconds=60))
+
+    with pytest.raises(ValueError):
+        await ingestor.from_bytes(data=b"1234", content_type="audio/wav")

--- a/services/dialog-engine/tests/unit/test_audio_preprocessor.py
+++ b/services/dialog-engine/tests/unit/test_audio_preprocessor.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+
+from dialog_engine.audio.preprocessor import AudioPreprocessor
+from dialog_engine.audio.types import AudioPayload
+
+
+@pytest.mark.asyncio
+async def test_preprocessor_fallback_allows_short_audio(monkeypatch):
+    monkeypatch.setattr("dialog_engine.audio.preprocessor.np", None)
+    monkeypatch.setattr("dialog_engine.audio.preprocessor.sf", None)
+
+    preprocessor = AudioPreprocessor(max_duration_seconds=1.0)
+    payload = AudioPayload(
+        data=b"rawpcm",
+        content_type="audio/wav",
+        sample_rate=16000,
+        channels=1,
+        duration_seconds=0.5,
+    )
+
+    bundle = await preprocessor.normalize(payload)
+
+    assert bundle.metadata.sample_rate == 16000
+    assert bundle.metadata.channels == 1
+    assert bundle.metadata.duration_seconds == pytest.approx(0.5)
+    assert bundle.pcm == payload.data
+
+
+@pytest.mark.asyncio
+async def test_preprocessor_fallback_enforces_duration_limit(monkeypatch):
+    monkeypatch.setattr("dialog_engine.audio.preprocessor.np", None)
+    monkeypatch.setattr("dialog_engine.audio.preprocessor.sf", None)
+
+    preprocessor = AudioPreprocessor(max_duration_seconds=0.5)
+    payload = AudioPayload(
+        data=b"rawpcm",
+        content_type="audio/wav",
+        sample_rate=16000,
+        channels=1,
+        duration_seconds=1.0,
+    )
+
+    with pytest.raises(ValueError):
+        await preprocessor.normalize(payload)

--- a/services/dialog-engine/tests/unit/test_chat_service.py
+++ b/services/dialog-engine/tests/unit/test_chat_service.py
@@ -7,6 +7,7 @@ from dialog_engine.chat_service import ChatService
 from dialog_engine.llm_client import LLMStreamEmptyError
 from dialog_engine.memory_store import MemoryTurn
 from dialog_engine.settings import (
+    AsrSettings,
     LLMSettings,
     LTMInlineSettings,
     OpenAISettings,
@@ -47,6 +48,20 @@ def _make_settings(
             retrieve_path="/ltm",
             timeout=1.0,
             max_snippets=3,
+        ),
+        asr=AsrSettings(
+            enabled=True,
+            provider="mock",
+            max_bytes=1024 * 1024,
+            max_duration_seconds=60.0,
+            target_sample_rate=16000,
+            target_channels=1,
+            default_lang="zh",
+            whisper_model="base",
+            whisper_device="auto",
+            whisper_compute_type="int8",
+            whisper_beam_size=1,
+            whisper_cache_dir=None,
         ),
     )
 

--- a/services/dialog-engine/tests/unit/test_memory_store.py
+++ b/services/dialog-engine/tests/unit/test_memory_store.py
@@ -46,3 +46,15 @@ async def test_fetch_recent_returns_turns(tmp_path: Path):
 
     assert [turn.role for turn in result] == ["user", "assistant", "system"]
     assert isinstance(result[0], MemoryTurn)
+
+
+@pytest.mark.asyncio
+async def test_append_turn_creates_db(tmp_path: Path):
+    db_path = tmp_path / "memory.sqlite"
+    store = ShortTermMemoryStore(db_path=str(db_path), default_limit=5)
+
+    await store.append_turn(session_id="sess", role="user", content="hello")
+
+    turns = await store.fetch_recent("sess")
+
+    assert turns and turns[-1].content == "hello"


### PR DESCRIPTION
## Summary
- add audio ingest, preprocessing, and ASR endpoints to dialog-engine
- integrate whisper provider plus memory and analytics wiring
- document audio usage and extend unit coverage for audio flow

## Testing
- not run (pytest not installed in env)
